### PR TITLE
Let tags be added via comma, enter or space

### DIFF
--- a/src/views/CustomTileDialog/AddCustomTile/index.jsx
+++ b/src/views/CustomTileDialog/AddCustomTile/index.jsx
@@ -90,6 +90,24 @@ export default function AddCustomTile({
     return setSubmitMessage({ message: t('customAdded'), type: 'success' });
   }
 
+  const handleKeyDown = (event) => {
+    switch (event.key) {
+      case ',':
+      case ' ': {
+        event.preventDefault();
+        event.stopPropagation();
+        if (event.target.value.length > 0) {
+          setFormData({
+            ...formData,
+            tags: [...formData.tags, event.target.value],
+          });
+        }
+        break;
+      }
+      default:
+    }
+  };
+
   return (
     <Accordion expanded={expanded === 'ctAdd'} onChange={handleChange('ctAdd')}>
       <AccordionSummary aria-controls="ctAdd-content" id="ctAdd-header">
@@ -139,9 +157,10 @@ export default function AddCustomTile({
             onChange={(_event, newValues) => {
               setFormData({ ...formData, tags: newValues });
             }}
-            renderInput={(params) => (
-              <TextField {...params} label={t('tags')} />
-            )}
+            renderInput={(params) => {
+              params.inputProps.onKeyDown = handleKeyDown;
+              return <TextField {...params} label={t('tags')} />;
+            }}
             sx={{ pb: 2 }}
             clearOnBlur
           />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tag input functionality by allowing users to add tags using comma and space key presses.
- **Bug Fixes**
	- Improved user experience by preventing default behavior for specific key presses in the tag input field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->