### PR TITLE
feat: add stripping category for local gameplay with multi-language support

### DIFF
--- a/src/locales/en/local/stripping.json
+++ b/src/locales/en/local/stripping.json
@@ -1,0 +1,33 @@
+{
+  "label": "Stripping",
+  "type": "foreplay",
+  "actions": {
+    "None": [],
+    "Article of Clothing": [
+      "{sub} removes one article of clothing.",
+      "Take off an article of clothing of your choice.",
+      "{sub} strips off one piece of clothing.",
+      "Remove a clothing item you're wearing.",
+      "Take off one item of clothing.",
+      "{dom} chooses another player to remove one article of clothing.",
+      "{dom} removes an article of clothing from {sub}.",
+      "{dom} has {sub} take off one piece of clothing.",
+      "Everyone removes one article of clothing.",
+      "The player with the most clothing removes an article.",
+      "{sub} removes their shirt or top.",
+      "Take off your socks or shoes.",
+      "Remove your outermost layer of clothing.",
+      "Strip down by one clothing item.",
+      "Undress by removing one piece.",
+      "Take off whatever clothing item you choose.",
+      "Remove the clothing item that was put on last.",
+      "Take off your least favorite piece of clothing currently worn.",
+      "{dom} removes a piece of clothing from {sub} using only their teeth.",
+      "{dom} uses only their mouth to remove an article of clothing from {sub}.",
+      "{dom} removes a piece of clothing from {sub} without using their hands.",
+      "{dom} has {sub} remove a piece of clothing from them.",
+      "{sub} lets {dom} choose and remove one of their clothing items.",
+      "{dom} gets to take off one piece of {sub}'s clothing."
+    ]
+  }
+}

--- a/src/locales/es/local/stripping.json
+++ b/src/locales/es/local/stripping.json
@@ -1,0 +1,33 @@
+{
+  "label": "Desnudarse",
+  "type": "foreplay",
+  "actions": {
+    "None": [],
+    "Prenda de Vestir": [
+      "{sub} se quita una prenda de vestir.",
+      "Retira una prenda de vestir de tu elección.",
+      "{sub} se deshace de una pieza de ropa.",
+      "Quita una prenda que lleves puesta.",
+      "Retira un artículo de vestir.",
+      "{dom} elige a otro jugador para que se quite una prenda de vestir.",
+      "{dom} quita una prenda de vestir a {sub}.",
+      "{dom} hace que {sub} se quite una pieza de ropa.",
+      "Todos se quitan una prenda de vestir.",
+      "El jugador con más ropa se quita una prenda.",
+      "{sub} se quita la camisa o la parte superior.",
+      "Quítate los calcetines o los zapatos.",
+      "Retira tu capa exterior de ropa.",
+      "Desnúdate quitándote una prenda.",
+      "Desvístete quitando una pieza.",
+      "Quítate la prenda de vestir que elijas.",
+      "Retira la prenda que te pusiste al final.",
+      "Quítate tu prenda menos favorita que llevas puesta.",
+      "{dom} quita una prenda de vestir a {sub} usando solo los dientes.",
+      "{dom} usa solo su boca para quitar una prenda de vestir a {sub}.",
+      "{dom} retira una prenda de vestir de {sub} sin usar las manos.",
+      "{dom} hace que {sub} le quite una prenda de vestir.",
+      "{sub} deja que {dom} elija y le quite una de sus prendas.",
+      "{dom} puede quitarle una pieza de ropa a {sub}."
+    ]
+  }
+}

--- a/src/locales/fr/local/stripping.json
+++ b/src/locales/fr/local/stripping.json
@@ -1,0 +1,33 @@
+{
+  "label": "Se Déshabiller",
+  "type": "foreplay",
+  "actions": {
+    "None": [],
+    "Vêtement": [
+      "{sub} retire un vêtement.",
+      "Enlève un vêtement de ton choix.",
+      "{sub} ôte une pièce de vêtement.",
+      "Retire un article vestimentaire que tu portes.",
+      "Enlève un vêtement.",
+      "{dom} choisit un autre joueur pour retirer un vêtement.",
+      "{dom} retire un vêtement de {sub}.",
+      "{dom} demande à {sub} d'enlever une pièce de vêtement.",
+      "Tout le monde retire un vêtement.",
+      "Le joueur avec le plus de vêtements en retire un.",
+      "{sub} retire son haut ou sa chemise.",
+      "Enlève tes chaussettes ou tes chaussures.",
+      "Retire ta couche extérieure de vêtements.",
+      "Déshabille-toi en retirant un vêtement.",
+      "Dévêts-toi en enlevant une pièce.",
+      "Retire le vêtement de ton choix.",
+      "Enlève le vêtement que tu as mis en dernier.",
+      "Retire ton vêtement le moins préféré que tu portes actuellement.",
+      "{dom} retire un vêtement de {sub} en utilisant seulement ses dents.",
+      "{dom} utilise seulement sa bouche pour retirer un vêtement de {sub}.",
+      "{dom} enlève un vêtement de {sub} sans utiliser ses mains.",
+      "{dom} demande à {sub} de lui retirer un vêtement.",
+      "{sub} laisse {dom} choisir et retirer un de ses vêtements.",
+      "{dom} peut enlever une pièce de vêtement à {sub}."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds new "stripping" category for local gameplay in all three supported languages (English, Spanish, French)
- Includes 24 varied actions with role-based variables ({dom}/{sub}) for interactive gameplay
- Two intensity levels: "None" (empty) and clothing removal level
- Enhanced migration system to prevent duplicate imports for existing users

## Features Added
- **Multi-language support**: Complete translations for EN, ES, FR
- **Varied action types**: Self-removal, interactive removal, hands-free challenges, group activities
- **Role-based gameplay**: Uses {dom}/{sub} variables for dynamic role assignment
- **Migration safety**: Version bump to 2.1.0 with enhanced deduplication logic

## Technical Changes
- Created `stripping.json` files in `src/locales/{lang}/local/` directories
- Updated `MIGRATION_VERSION` from 2.0.0 to 2.1.0 to force re-migration
- Enhanced tile deduplication in migration service to prevent duplicate actions
- All changes pass existing test suite automatically

## Test Plan
- [x] Locale validation tests pass (automatic file discovery and validation)
- [x] Build system correctly includes new files
- [x] ESLint passes with no style violations  
- [x] Migration system handles existing users without creating duplicates
- [x] All three language files have consistent structure and translations

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English, Spanish, and French localization support for "Stripping" foreplay actions, including a variety of action phrases for interactive scenarios.

* **Bug Fixes**
  * Improved import process to prevent duplicate custom tiles during migration, ensuring cleaner data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->