### PR TITLE
fix: resolve i18next duplicate key error for 'messages' translation

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -373,7 +373,7 @@
     "exportFailed": "Export failed: {{error}}",
     "importFailed": "Import failed: {{errors}}"
   },
-  "messages": {
+  "importMessages": {
     "importing": "Importing data...",
     "importSuccess": "Import completed successfully!",
     "importedGroups": "Imported {{count}} custom groups.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -375,7 +375,7 @@
     "exportFailed": "Error en la exportación: {{error}}",
     "importFailed": "Error en la importación: {{errors}}"
   },
-  "messages": {
+  "importMessages": {
     "importing": "Importando datos...",
     "importSuccess": "¡Importación completada exitosamente!",
     "importedGroups": "Se importaron {{count}} grupos personalizados.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -375,7 +375,7 @@
     "exportFailed": "Échec de l'exportation : {{error}}",
     "importFailed": "Échec de l'importation : {{errors}}"
   },
-  "messages": {
+  "importMessages": {
     "importing": "Importation des données...",
     "importSuccess": "Importation terminée avec succès !",
     "importedGroups": "{{count}} groupes personnalisés importés.",

--- a/src/views/CustomTileDialog/ImportExport/index.tsx
+++ b/src/views/CustomTileDialog/ImportExport/index.tsx
@@ -137,7 +137,7 @@ export default function ImportExport({
     }
 
     try {
-      setSubmitMessage({ type: 'info', message: t('messages.importing') });
+      setSubmitMessage({ type: 'info', message: t('importMessages.importing') });
 
       // Use the new auto-import function that detects format
       const result = await autoImportData(importDataValue, mappedGroups, {
@@ -160,12 +160,12 @@ export default function ImportExport({
           });
         }
 
-        let message: string = t('messages.importSuccess');
+        let message: string = t('importMessages.importSuccess');
         if (result.importedGroups > 0) {
-          message += ` ${t('messages.importedGroups', { count: result.importedGroups })}`;
+          message += ` ${t('importMessages.importedGroups', { count: result.importedGroups })}`;
         }
         if (result.importedTiles > 0) {
-          message += ` ${t('messages.importedTiles', { count: result.importedTiles })}`;
+          message += ` ${t('importMessages.importedTiles', { count: result.importedTiles })}`;
         }
 
         setSubmitMessage({


### PR DESCRIPTION
Fixes the i18next error "Key 'messages (en)' returned an object instead of string" that was appearing on the mobile bottom menu. The issue was caused by duplicate 'messages' keys in translation files - one for the tab label and another for import-related messages.

Changes:
- Rename 'messages' object to 'importMessages' in all translation files
- Update ImportExport component to use new 'importMessages' namespace
- Maintain backward compatibility for existing translations

The bottom menu now properly displays "Messages" instead of the i18next error.

🤖 Generated with [Claude Code](https://claude.ai/code)