### PR TITLE
Fix language switching migration issue

### DIFF
--- a/src/services/__tests__/migrationService.test.ts
+++ b/src/services/__tests__/migrationService.test.ts
@@ -159,7 +159,7 @@ describe('Migration Service', () => {
       expect(isMigrationCompleted()).toBe(false);
     });
 
-    it('should properly mark migration as completed after successful run', async () => {
+    it('should properly mark current language migration as completed after successful run', async () => {
       // Start with no migration status
       expect(isMigrationCompleted()).toBe(false);
 
@@ -170,8 +170,12 @@ describe('Migration Service', () => {
       const result = await runMigrationIfNeeded();
       expect(result).toBe(true);
 
-      // Check that migration was marked as completed
-      expect(isMigrationCompleted()).toBe(true);
+      // Check that current language was marked as migrated (not full migration yet)
+      const { isCurrentLanguageMigrationCompleted } = await import('../migrationService');
+      expect(isCurrentLanguageMigrationCompleted('en')).toBe(true);
+
+      // Main migration should not be marked complete yet (only when all languages are done)
+      expect(isMigrationCompleted()).toBe(false);
     });
   });
 

--- a/src/services/migrationService.ts
+++ b/src/services/migrationService.ts
@@ -178,12 +178,22 @@ export const isCurrentLanguageMigrationCompleted = (locale: string): boolean => 
       }
     }
 
-    // Fallback: check if full migration is complete (this means ALL languages are done)
+    // Fallback: check if full migration is complete AND all languages are done
     const status = localStorage.getItem(MIGRATION_KEY);
     if (status) {
       const migrationStatus: MigrationStatus = JSON.parse(status);
 
       if (migrationStatus.completed && migrationStatus.version === MIGRATION_VERSION) {
+        // Only return true if this is a full migration (not just current language)
+        // Check if background migration has completed all languages
+        if (bgStatus) {
+          const backgroundStatus: BackgroundMigrationStatus = JSON.parse(bgStatus);
+          const allLanguagesCompleted = SUPPORTED_LANGUAGES.every((lang) =>
+            backgroundStatus.completedLanguages.includes(lang)
+          );
+          return allLanguagesCompleted;
+        }
+        // If no background status, assume full migration means all languages are done
         return true;
       }
     }
@@ -843,8 +853,10 @@ export const ensureLanguageMigrated = async (locale: string): Promise<boolean> =
  */
 export const runMigrationIfNeeded = async (): Promise<boolean> => {
   try {
-    // Check if full migration is already completed
-    if (isMigrationCompleted()) {
+    const currentLocale = await getCurrentLanguage();
+
+    // Check if full migration is already completed OR current language is already migrated
+    if (isMigrationCompleted() || isCurrentLanguageMigrationCompleted(currentLocale)) {
       return true;
     }
 
@@ -872,15 +884,12 @@ export const runMigrationIfNeeded = async (): Promise<boolean> => {
     setMigrationInProgress(true);
 
     try {
-      const currentLocale = await getCurrentLanguage();
-
       // Fast path: migrate current language only
       const success = await migrateCurrentLanguage(currentLocale);
 
       if (success) {
-        // Mark main migration as complete for fresh user scenario
-        // This allows the app to proceed normally while background migration continues
-        markMigrationComplete();
+        // Don't mark main migration as complete yet - only mark the current language as complete
+        // The main migration will be marked complete when all languages are done in background migration
 
         // Queue background migration for other languages
         queueBackgroundMigration(currentLocale);

--- a/src/services/migrationService.ts
+++ b/src/services/migrationService.ts
@@ -170,9 +170,11 @@ export const isCurrentLanguageMigrationCompleted = (locale: string): boolean => 
   try {
     // First check background migration status for specific language
     const bgStatus = localStorage.getItem(BACKGROUND_MIGRATION_KEY);
+    let backgroundStatus: BackgroundMigrationStatus | null = null;
+
     if (bgStatus) {
-      const backgroundStatus: BackgroundMigrationStatus = JSON.parse(bgStatus);
-      const isCompleted = backgroundStatus.completedLanguages.includes(locale);
+      backgroundStatus = JSON.parse(bgStatus);
+      const isCompleted = backgroundStatus!.completedLanguages.includes(locale);
       if (isCompleted) {
         return true;
       }
@@ -186,10 +188,9 @@ export const isCurrentLanguageMigrationCompleted = (locale: string): boolean => 
       if (migrationStatus.completed && migrationStatus.version === MIGRATION_VERSION) {
         // Only return true if this is a full migration (not just current language)
         // Check if background migration has completed all languages
-        if (bgStatus) {
-          const backgroundStatus: BackgroundMigrationStatus = JSON.parse(bgStatus);
+        if (backgroundStatus) {
           const allLanguagesCompleted = SUPPORTED_LANGUAGES.every((lang) =>
-            backgroundStatus.completedLanguages.includes(lang)
+            backgroundStatus!.completedLanguages.includes(lang)
           );
           return allLanguagesCompleted;
         }
@@ -855,8 +856,8 @@ export const runMigrationIfNeeded = async (): Promise<boolean> => {
   try {
     const currentLocale = await getCurrentLanguage();
 
-    // Check if full migration is already completed OR current language is already migrated
-    if (isMigrationCompleted() || isCurrentLanguageMigrationCompleted(currentLocale)) {
+    // Check if the current language is already migrated
+    if (isCurrentLanguageMigrationCompleted(currentLocale)) {
       return true;
     }
 


### PR DESCRIPTION
## Summary
- Fixes migration logic to properly handle individual language migrations
- Resolves issue where actions wouldn't load for non-default locales after language switching
- Ensures `ensureLanguageMigrated()` actually migrates data when switching languages

## Problem
When users switched languages, the app would fail to load action groups and tiles for non-default locales. This was caused by:

1. The migration system prematurely marking the entire migration as "complete" after only migrating the current language on app startup
2. `isCurrentLanguageMigrationCompleted()` incorrectly returning `true` for all languages when the main migration was marked complete
3. `ensureLanguageMigrated()` skipping migration because it thought the language was already migrated

## Solution
- **Fixed `isCurrentLanguageMigrationCompleted()`**: Now properly checks if a specific language has been migrated, rather than just checking if the main migration is complete
- **Fixed `runMigrationIfNeeded()`**: Removed the premature `markMigrationComplete()` call - main migration is now only marked complete when ALL languages are migrated
- **Improved language-specific migration tracking**: Better separation between individual language completion and full migration completion

## Test plan
- [x] Verify default language loads properly on app startup
- [x] Switch to Spanish/French and confirm actions load correctly
- [x] Switch back to English and verify functionality remains intact
- [x] Background migration continues to work for remaining languages
- [x] No regression in existing migration functionality

🤖 Generated with [Claude Code](https://claude.ai/code)