### PR TITLE
fix: resolve consume action toggle logic issue in setup wizard

### DIFF
--- a/src/views/GameSettingsWizard/ActionsStep/PickConsumptions/__tests__/PickConsumptions.test.tsx
+++ b/src/views/GameSettingsWizard/ActionsStep/PickConsumptions/__tests__/PickConsumptions.test.tsx
@@ -1,0 +1,383 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PickConsumptions from '../index';
+import { FormData } from '@/types';
+import * as helpers from '@/views/GameSettingsWizard/ActionsStep/helpers';
+
+// Mock i18next
+vi.mock('i18next', () => ({
+  t: vi.fn((key: string) => key),
+}));
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  Trans: ({ i18nKey, children }: { i18nKey: string; children?: React.ReactNode }) =>
+    children || i18nKey,
+}));
+
+// Mock the helper functions
+vi.mock('@/views/GameSettingsWizard/ActionsStep/helpers', () => ({
+  populateSelections: vi.fn(() => ['alcohol', 'poppers']),
+  updateFormDataWithDefaults: vi.fn(),
+  handleChange: vi.fn(),
+}));
+
+// Mock MultiSelect component
+vi.mock('@/components/MultiSelect', () => ({
+  default: ({ onChange, values, options, label }: any) => (
+    <div data-testid="multi-select">
+      <label>{label}</label>
+      <select
+        multiple
+        value={values}
+        onChange={(e) => {
+          const selectedValues = Array.from(e.target.selectedOptions, (option) => option.value);
+          onChange({ target: { value: selectedValues } });
+        }}
+        data-testid="consumption-select"
+      >
+        {options.map((option: any) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  ),
+}));
+
+// Mock YesNoSwitch component
+vi.mock('@/components/GameForm/YesNoSwitch', () => ({
+  default: ({ trueCondition, onChange, yesLabel }: any) => (
+    <div data-testid="yes-no-switch">
+      <label>
+        <input
+          type="checkbox"
+          checked={trueCondition || false}
+          onChange={(e) => onChange(e, e.target.checked)}
+          data-testid="toggle-checkbox"
+        />
+        {yesLabel}
+      </label>
+    </div>
+  ),
+}));
+
+// Mock IncrementalSelect component
+vi.mock('@/components/GameForm/IncrementalSelect', () => ({
+  default: ({ option, onChange }: any) => (
+    <div data-testid={`incremental-select-${option}`}>
+      <label>{option}</label>
+      <input
+        type="number"
+        onChange={(e) => onChange({ target: { value: parseInt(e.target.value) } })}
+        data-testid={`intensity-input-${option}`}
+      />
+    </div>
+  ),
+}));
+
+// Mock IntensityTitle component
+vi.mock('@/views/GameSettingsWizard/ActionsStep/IntensityTitle', () => ({
+  default: () => <div data-testid="intensity-title">Intensity Title</div>,
+}));
+
+describe('PickConsumptions', () => {
+  const mockSetFormData = vi.fn();
+  const mockOptions = vi.fn(() => [
+    { value: 'alcohol', label: 'Alcohol' },
+    { value: 'poppers', label: 'Poppers' },
+    { value: 'vaping', label: 'Vaping' },
+  ]);
+  const mockActionsList = {
+    alcohol: { label: 'Alcohol' },
+    poppers: { label: 'Poppers' },
+    vaping: { label: 'Vaping' },
+  };
+
+  const defaultFormData: FormData = {
+    gameMode: 'online' as any,
+    room: 'TEST',
+    boardUpdated: false,
+    isAppend: false,
+    selectedActions: {
+      alcohol: {
+        type: 'consumption',
+        level: 2,
+        variation: 'standalone',
+      },
+      poppers: {
+        type: 'consumption',
+        level: 1,
+        variation: 'standalone',
+      },
+    },
+  };
+
+  const defaultProps = {
+    formData: defaultFormData,
+    setFormData: mockSetFormData,
+    options: mockOptions,
+    actionsList: mockActionsList,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Component Rendering', () => {
+    it('should render the component with basic elements', () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      expect(screen.getByText('pickConsumptions')).toBeInTheDocument();
+      expect(screen.getByTestId('multi-select')).toBeInTheDocument();
+    });
+
+    it('should show toggle and intensity controls when consumptions are selected', () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      expect(screen.getByTestId('intensity-title')).toBeInTheDocument();
+      expect(screen.getByTestId('yes-no-switch')).toBeInTheDocument();
+      expect(screen.getByText('standaloneOrCombine')).toBeInTheDocument();
+    });
+
+    it('should render incremental selects for each selected consumption', () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      expect(screen.getByTestId('incremental-select-alcohol')).toBeInTheDocument();
+      expect(screen.getByTestId('incremental-select-poppers')).toBeInTheDocument();
+    });
+  });
+
+  describe('Toggle Functionality', () => {
+    it('should show toggle as unchecked when isAppend is false', () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      expect(toggleCheckbox).not.toBeChecked();
+    });
+
+    it('should show toggle as checked when isAppend is true', () => {
+      const formDataWithAppend = {
+        ...defaultFormData,
+        isAppend: true,
+      };
+
+      render(<PickConsumptions {...defaultProps} formData={formDataWithAppend} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      expect(toggleCheckbox).toBeChecked();
+    });
+
+    it('should update selectedActions with appendMost when toggle is turned ON', async () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        expect(mockSetFormData).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isAppend: true,
+            selectedActions: expect.objectContaining({
+              alcohol: expect.objectContaining({
+                variation: 'appendMost',
+              }),
+              poppers: expect.objectContaining({
+                variation: 'appendMost',
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should update selectedActions with standalone when toggle is turned OFF', async () => {
+      const formDataWithAppend = {
+        ...defaultFormData,
+        isAppend: true,
+        selectedActions: {
+          alcohol: {
+            type: 'consumption',
+            level: 2,
+            variation: 'appendMost',
+          },
+          poppers: {
+            type: 'consumption',
+            level: 1,
+            variation: 'appendMost',
+          },
+        },
+      };
+
+      render(<PickConsumptions {...defaultProps} formData={formDataWithAppend} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        expect(mockSetFormData).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isAppend: false,
+            selectedActions: expect.objectContaining({
+              alcohol: expect.objectContaining({
+                variation: 'standalone',
+              }),
+              poppers: expect.objectContaining({
+                variation: 'standalone',
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should preserve other properties when updating variation', async () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        expect(mockSetFormData).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selectedActions: expect.objectContaining({
+              alcohol: expect.objectContaining({
+                type: 'consumption',
+                level: 2,
+                variation: 'appendMost',
+              }),
+              poppers: expect.objectContaining({
+                type: 'consumption',
+                level: 1,
+                variation: 'appendMost',
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should not show controls when no consumptions are selected', async () => {
+      // Override the mock to return empty array for this test
+      vi.mocked(helpers.populateSelections).mockReturnValueOnce([]);
+
+      const formDataEmpty = {
+        ...defaultFormData,
+        selectedActions: {},
+      };
+
+      render(<PickConsumptions {...defaultProps} formData={formDataEmpty} />);
+
+      // When no consumptions are selected, the toggle should not be visible
+      expect(screen.queryByTestId('toggle-checkbox')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('intensity-title')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle selectedActions with missing consumption items', async () => {
+      const formDataPartial = {
+        ...defaultFormData,
+        selectedActions: {
+          alcohol: {
+            type: 'consumption',
+            level: 2,
+            variation: 'standalone',
+          },
+          // Missing poppers entry
+        },
+      };
+
+      render(<PickConsumptions {...defaultProps} formData={formDataPartial} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        expect(mockSetFormData).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isAppend: true,
+            selectedActions: expect.objectContaining({
+              alcohol: expect.objectContaining({
+                variation: 'appendMost',
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should not update non-existent consumption items', async () => {
+      const formDataWithExtra = {
+        ...defaultFormData,
+        selectedActions: {
+          alcohol: {
+            type: 'consumption',
+            level: 2,
+            variation: 'standalone',
+          },
+          someOtherAction: {
+            type: 'solo',
+            level: 1,
+            variation: 'standalone',
+          },
+        },
+      };
+
+      render(<PickConsumptions {...defaultProps} formData={formDataWithExtra} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        const callArgs = mockSetFormData.mock.calls[0][0];
+        expect(callArgs.selectedActions.alcohol.variation).toBe('appendMost');
+        expect(callArgs.selectedActions.someOtherAction.variation).toBe('standalone'); // Should remain unchanged
+      });
+    });
+  });
+
+  describe('Data Consistency', () => {
+    it('should maintain synchronization between isAppend and variation values', async () => {
+      render(<PickConsumptions {...defaultProps} />);
+
+      // Toggle ON
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        const callArgs = mockSetFormData.mock.calls[0][0];
+        expect(callArgs.isAppend).toBe(true);
+        expect(callArgs.selectedActions.alcohol.variation).toBe('appendMost');
+        expect(callArgs.selectedActions.poppers.variation).toBe('appendMost');
+      });
+    });
+
+    it('should update all selected consumption items when toggle changes', async () => {
+      const formDataMultiple = {
+        ...defaultFormData,
+        selectedActions: {
+          alcohol: { type: 'consumption', level: 2, variation: 'standalone' },
+          poppers: { type: 'consumption', level: 1, variation: 'standalone' },
+          vaping: { type: 'consumption', level: 3, variation: 'standalone' },
+        },
+      };
+
+      // Mock to return all three items as selected
+      vi.mocked(helpers.populateSelections).mockReturnValue(['alcohol', 'poppers', 'vaping']);
+
+      render(<PickConsumptions {...defaultProps} formData={formDataMultiple} />);
+
+      const toggleCheckbox = screen.getByTestId('toggle-checkbox');
+      fireEvent.click(toggleCheckbox);
+
+      await waitFor(() => {
+        const callArgs = mockSetFormData.mock.calls[0][0];
+        expect(callArgs.selectedActions.alcohol.variation).toBe('appendMost');
+        expect(callArgs.selectedActions.poppers.variation).toBe('appendMost');
+        expect(callArgs.selectedActions.vaping.variation).toBe('appendMost');
+      });
+    });
+  });
+});

--- a/src/views/GameSettingsWizard/ActionsStep/PickConsumptions/index.tsx
+++ b/src/views/GameSettingsWizard/ActionsStep/PickConsumptions/index.tsx
@@ -42,17 +42,25 @@ export default function PickConsumptions({
   };
 
   const variationChange = (event: ChangeEvent<HTMLInputElement>, selectedItems: string[]) => {
-    const updatedFormData = selectedItems.reduce<FormData>(
-      (acc, option) => {
-        acc[option] = {
-          ...((acc[option] as object) || {}),
-          type: action,
-          variation: event.target.checked ? 'appendMost' : 'standalone',
+    const newVariation = event.target.checked ? 'appendMost' : 'standalone';
+    const newIsAppend = event.target.checked;
+
+    // Update selectedActions for each consumption item
+    const updatedSelectedActions = { ...formData.selectedActions };
+    selectedItems.forEach((option) => {
+      if (updatedSelectedActions[option]) {
+        updatedSelectedActions[option] = {
+          ...updatedSelectedActions[option],
+          variation: newVariation,
         };
-        return acc;
-      },
-      { ...formData, isAppend: event.target.checked }
-    );
+      }
+    });
+
+    const updatedFormData = {
+      ...formData,
+      isAppend: newIsAppend,
+      selectedActions: updatedSelectedActions,
+    };
 
     setFormData(updatedFormData);
   };


### PR DESCRIPTION
## Summary

Fix issue where the "Combine them with the other actions" toggle in the setup wizard wasn't properly setting the variation value for consumption items. When the toggle was ON (combine), the game would still show "Standalone Tile" instead of combining with other actions.

## Problem

- The `variationChange` function wasn't updating the `selectedActions` structure correctly
- Toggle state (`isAppend`) and variation values were not synchronized  
- Consumption items retained old variation values when the toggle changed
- This caused consumption actions to appear as standalone tiles even when the user selected to combine them

## Solution

- Refactored `variationChange` function to properly update the `selectedActions` nested structure
- Ensured immediate synchronization between toggle state and variation values for all selected consumption items
- Preserved all existing properties while updating the variation field
- Fixed the data flow from wizard toggle → selectedActions → game builder

## Changes Made

### Code Changes
- **`src/views/GameSettingsWizard/ActionsStep/PickConsumptions/index.tsx`**: Fixed the `variationChange` function to properly update `selectedActions` structure

### Testing
- **`src/views/GameSettingsWizard/ActionsStep/PickConsumptions/__tests__/PickConsumptions.test.tsx`**: Added comprehensive test suite covering:
  - Toggle ON sets `variation: 'appendMost'` for all consumption items
  - Toggle OFF sets `variation: 'standalone'` for all consumption items  
  - Data consistency between `isAppend` flag and variation values
  - Edge cases and error handling
  - Component rendering with different states

## Validation

### Before Fix
- Toggle ON ("Combine them with the other actions") → Still showed "Standalone Tile" in game
- `isAppend: true` but `variation: 'standalone'` in selectedActions

### After Fix  
- Toggle ON → Sets `variation: 'appendMost'` → Game shows combined actions
- Toggle OFF → Sets `variation: 'standalone'` → Game shows standalone tiles
- Perfect synchronization between toggle state and game behavior

## Test Results

- ✅ All 13 new tests pass
- ✅ Full test suite passes (361 tests)  
- ✅ TypeScript compilation successful
- ✅ ESLint passes with no errors
- ✅ Code auto-formatted by pre-commit hooks

## Test Plan

1. Go to setup wizard
2. Select consumption actions (e.g., alcohol, poppers)
3. Toggle "Combine them with the other actions" ON
4. Build game and verify consumption actions are combined with other actions
5. Toggle OFF and verify consumption actions appear as standalone tiles

🤖 Generated with [Claude Code](https://claude.ai/code)