### PR TITLE
Fix production React createContext error from react-i18next

### DIFF
--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useRef, ReactNode, createContext, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useRef, ReactNode, useCallback } from 'react';
 import { getAuth } from 'firebase/auth';
 import {
   loginAnonymously,
@@ -42,7 +42,7 @@ export interface AuthContextType {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = React.createContext<AuthContextType | undefined>(undefined);
 
 interface AuthProviderProps {
   children: ReactNode;

--- a/src/context/messages.tsx
+++ b/src/context/messages.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { Params, useParams } from 'react-router-dom';
 import { getMessages } from '@/services/firebase';
 import { Message } from '@/types/Message';
@@ -10,7 +10,7 @@ export interface MessagesContextType {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const MessagesContext = createContext<MessagesContextType | undefined>(undefined);
+export const MessagesContext = React.createContext<MessagesContextType | undefined>(undefined);
 
 interface MessagesProviderProps {
   children: ReactNode;

--- a/src/context/schedule.tsx
+++ b/src/context/schedule.tsx
@@ -1,4 +1,4 @@
-import { createContext, useMemo, useEffect, useCallback, ReactNode, useRef } from 'react';
+import React, { useMemo, useEffect, useCallback, ReactNode, useRef } from 'react';
 import { getSchedule, addSchedule } from '@/services/firebase';
 import { DocumentReference, DocumentData } from 'firebase/firestore';
 import dayjs from 'dayjs';
@@ -22,7 +22,7 @@ export interface ScheduleContextType {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const ScheduleContext = createContext<ScheduleContextType | undefined>(undefined);
+export const ScheduleContext = React.createContext<ScheduleContextType | undefined>(undefined);
 
 interface ScheduleProviderProps {
   children: ReactNode;

--- a/src/context/userList.tsx
+++ b/src/context/userList.tsx
@@ -1,4 +1,4 @@
-import { createContext, useMemo, useEffect, useCallback, ReactNode, useRef } from 'react';
+import React, { useMemo, useEffect, useCallback, ReactNode, useRef } from 'react';
 import { Params, useParams } from 'react-router-dom';
 import { getUserList } from '@/services/firebase';
 import { useUserListStore } from '@/stores/userListStore';
@@ -15,7 +15,7 @@ export interface UserListContextType {
 }
 
 // eslint-disable-next-line react-refresh/only-export-components
-export const UserListContext = createContext<UserListContextType | undefined>(undefined);
+export const UserListContext = React.createContext<UserListContextType | undefined>(undefined);
 
 interface UserListProviderProps {
   children: ReactNode;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { AuthProvider } from './context/auth';
-import './i18n';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
+import './i18n';
 
 // Optimize font loading - only import essential weights initially
 import '@fontsource/roboto/400.css'; // Regular weight only for faster initial load

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
             'react-dom',
             'react-router',
             'react-router-dom',
+            'i18next',
+            'react-i18next',
+            'i18next-browser-languagedetector',
+            'i18next-resources-to-backend',
             '@mui/material',
             '@emotion/react',
             '@emotion/styled',
@@ -48,19 +52,7 @@ export default defineConfig({
             'firebase/storage',
           ],
           // Bundle utilities together
-          utils: [
-            'zustand',
-            'dexie',
-            'dexie-react-hooks',
-            'dayjs',
-            'nanoid',
-            'clsx',
-            'js-sha256',
-            'i18next',
-            'react-i18next',
-            'i18next-browser-languagedetector',
-            'i18next-resources-to-backend',
-          ],
+          utils: ['zustand', 'dexie', 'dexie-react-hooks', 'dayjs', 'nanoid', 'clsx', 'js-sha256'],
         },
         // Optimize chunk sizes
         chunkFileNames: (chunkInfo) => {


### PR DESCRIPTION
## Summary
Fixes production build error: `Cannot read properties of undefined (reading 'createContext')`

The error occurred when `react-i18next`'s `initReactI18next` plugin tried to call `React.createContext()` before React was available in production builds.

## Root Cause
The issue was in the chunk loading order - i18n libraries were in a separate `utils` chunk that could load before the `vendor` chunk containing React, causing `createContext` to be called on an undefined React object.

## Changes Made
- **Vite Configuration**: Moved i18n libraries to vendor chunk with React to ensure proper load order
- **Import Order**: Reordered i18n import in `index.jsx` to load after React
- **React Imports**: Standardized all context files to use `React.createContext()` for better reliability

## Files Modified
- `vite.config.ts` - Updated chunk configuration
- `src/index.jsx` - Reordered imports  
- `src/context/auth.tsx` - Updated React imports
- `src/context/messages.tsx` - Updated React imports
- `src/context/schedule.tsx` - Updated React imports
- `src/context/userList.tsx` - Updated React imports

## Test plan
- [x] Production build completes successfully
- [x] No createContext errors in console
- [x] All context providers function correctly
- [x] i18n initialization works properly

🤖 Generated with [Claude Code](https://claude.ai/code)