### PR TITLE
Fix React Hook useMemo unnecessary dependency warning

### DIFF
--- a/src/views/UnauthenticatedApp/index.tsx
+++ b/src/views/UnauthenticatedApp/index.tsx
@@ -106,7 +106,7 @@ export default function UnauthenticatedApp() {
           {obj.label}
         </MenuItem>
       )),
-    [languages]
+    []
   );
 
   return (


### PR DESCRIPTION
## Summary
Fixes ESLint warning in `src/views/UnauthenticatedApp/index.tsx` for unnecessary dependency in `useMemo` hook.

## Issue
The `useMemo` hook had `languages` in its dependency array, but since `languages` is a static import from `@/services/i18nHelpers`, it never changes during the component's lifecycle.

ESLint warning:
```
React Hook useMemo has an unnecessary dependency: 'languages'. 
Either exclude it or remove the dependency array. Outer scope values 
like 'languages' aren't valid dependencies because mutating them 
doesn't re-render the component
```

## Solution
Removed `languages` from the dependency array since it's a static constant.

### Before
```typescript
const languageMenuItems = useMemo(
  () => Object.entries(languages).map(([key, obj]) => (
    <MenuItem value={key} key={key}>{obj.label}</MenuItem>
  )),
  [languages] // ← Unnecessary dependency
);
```

### After
```typescript
const languageMenuItems = useMemo(
  () => Object.entries(languages).map(([key, obj]) => (
    <MenuItem value={key} key={key}>{obj.label}</MenuItem>
  )),
  [] // ← Empty dependency array since languages is static
);
```

## Test plan
- [x] ESLint passes with no warnings
- [x] TypeScript compilation successful
- [x] No functional changes - component behavior unchanged

## Impact
- ✅ Eliminates ESLint warning
- ✅ Follows React Hook best practices
- ✅ Prevents unnecessary re-computation of static data
- ✅ No functional changes to user experience

🤖 Generated with [Claude Code](https://claude.ai/code)