### PR TITLE
feat: improve UX in game settings wizard

### DIFF
--- a/src/views/GameSettings/index.tsx
+++ b/src/views/GameSettings/index.tsx
@@ -21,11 +21,13 @@ import validateFormData from './validateForm';
 interface GameSettingsProps {
   closeDialog?: () => void;
   initialTab?: number;
+  onOpenSetupWizard?: () => void;
 }
 
 export default function GameSettings({
   closeDialog,
   initialTab = 0,
+  onOpenSetupWizard,
 }: GameSettingsProps): JSX.Element {
   const { user } = useAuth();
   const { t } = useTranslation();
@@ -140,9 +142,18 @@ export default function GameSettings({
       </TabPanel>
 
       <div className="flex-buttons">
-        <Button variant="outlined" type="button" onClick={() => setOpenCustomTile(true)}>
-          <Trans i18nKey="customTilesLabel">Game Tiles</Trans>
-        </Button>
+        <div className="left-buttons">
+          {onOpenSetupWizard && (
+            <Button variant="outlined" type="button" onClick={onOpenSetupWizard}>
+              <Trans i18nKey="setupWizard" />
+            </Button>
+          )}
+          {value === 0 && (
+            <Button variant="outlined" type="button" onClick={() => setOpenCustomTile(true)}>
+              <Trans i18nKey="customTilesLabel">Game Tiles</Trans>
+            </Button>
+          )}
+        </div>
         <Button variant="contained" type="submit">
           <Trans i18nKey="update" />
         </Button>

--- a/src/views/GameSettings/styles.css
+++ b/src/views/GameSettings/styles.css
@@ -13,12 +13,14 @@ label.settings-switch {
   margin-top: 1rem;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+}
+
+.left-buttons {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .flex-buttons > button {
-  margin-right: 0.5rem;
-}
-
-.flex-buttons > button:last-child {
-  margin-right: 0;
+  margin-left: auto;
 }

--- a/src/views/GameSettingsWizard/ActionsStep/index.tsx
+++ b/src/views/GameSettingsWizard/ActionsStep/index.tsx
@@ -52,6 +52,16 @@ export default function ActionsStep({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- This should only run once on mount to clean initial data
   }, []);
 
+  // Auto-open accordion if there are selected actions on mount
+  useEffect(() => {
+    const hasSelectedActions =
+      formData.selectedActions && Object.keys(formData.selectedActions).length > 0;
+    if (hasSelectedActions) {
+      setShowCustomization(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run on mount
+  }, []);
+
   const options = (key: string) =>
     settingSelectLists(key).map((option) => ({
       value: option,

--- a/src/views/GameSettingsWizard/GameModeStep/index.tsx
+++ b/src/views/GameSettingsWizard/GameModeStep/index.tsx
@@ -90,10 +90,9 @@ export default function GameModeStep({
                 backgroundColor: mode.isSelected ? 'primary.50' : 'background.paper',
                 transition: 'all 0.2s ease-in-out',
                 height: '100%',
-                transform: mode.isSelected ? 'scale(1.02)' : 'scale(1)',
                 '&:hover': {
                   borderColor: 'primary.main',
-                  transform: 'scale(1.02)',
+                  transform: 'translateY(-2px)',
                   boxShadow: 2,
                 },
               }}

--- a/src/views/GameSettingsWizard/index.tsx
+++ b/src/views/GameSettingsWizard/index.tsx
@@ -87,6 +87,17 @@ export default function GameSettingsWizard({ close }: GameSettingsWizardProps) {
 
   const goToAdvanced = (): void => setStep(0); // Use 0 to represent 'advanced'
 
+  const goToSetupWizard = (): void => {
+    // Reset to the appropriate step based on a room type and current settings
+    if (isPublicRoom(room)) {
+      setStep(3); // Skip to the "actions" step for public rooms
+    } else if (formData.gameMode === 'online') {
+      setStep(3); // Skip to the "actions" step if already online
+    } else {
+      setStep(1); // Start from the beginning
+    }
+  };
+
   const renderStep = (): JSX.Element | null => {
     switch (step) {
       case 1:
@@ -125,7 +136,7 @@ export default function GameSettingsWizard({ close }: GameSettingsWizardProps) {
     }
   };
 
-  if (step === 0) return <GameSettings closeDialog={close} />;
+  if (step === 0) return <GameSettings closeDialog={close} onOpenSetupWizard={goToSetupWizard} />;
 
   return (
     <Box>


### PR DESCRIPTION
## Summary
- Add Setup Wizard button to advanced settings for easy navigation back to wizard
- Improve button layout in GameSettings with consistent right-aligned Update button  
- Auto-expand Customize Actions accordion when actions are already selected
- Standardize hover effects across GameModeStep for consistent user interaction
- Game Tiles button now only shows on Board tab for cleaner interface

## Test plan
- [x] Setup Wizard button appears in advanced settings when accessed through wizard
- [x] Setup Wizard button intelligently navigates to appropriate step based on room/mode
- [x] Update button stays right-aligned on all tabs regardless of other buttons present
- [x] Game Tiles button only shows on Board tab (tab 0)
- [x] Customize Actions accordion auto-opens when selectedActions has values
- [x] GameModeStep hover effects are consistent across all button sections

🤖 Generated with [Claude Code](https://claude.ai/code)