### PR TITLE
feat: configure mobile development environment

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <!-- CSP temporarily disabled for mobile development testing -->
-    <!-- <meta http-equiv="Content-Security-Policy" content="
-      default-src 'self' http://10.0.2.2:* http://localhost:*; 
+    <!-- CSP with relaxed policies for mobile development testing -->
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self' http://10.0.2.2:* http://localhost:* ws://localhost:* ws://10.0.2.2:*; 
       script-src 'self' 'unsafe-inline' 'unsafe-eval' 
         http://10.0.2.2:* http://localhost:*
         https://www.googletagmanager.com 
@@ -45,6 +45,7 @@
         blob:; 
       connect-src 'self' 
         http://10.0.2.2:* http://localhost:*
+        ws://localhost:* ws://10.0.2.2:*
         https://*.firebaseio.com 
         https://*.googleapis.com 
         https://*.firebaseapp.com 
@@ -58,7 +59,7 @@
       base-uri 'self'; 
       form-action 'self' 
         https://accounts.google.com;
-    " /> -->
+    " />
     <meta
       name="description"
       content="An adult multiplayer sex board game for those with various kinks. Great for solo play, couples or parties. Tailored primarily for men, but accessible by women too."

--- a/index.html
+++ b/index.html
@@ -20,39 +20,45 @@
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta http-equiv="Content-Security-Policy" content="
-      default-src 'self'; 
+    <!-- CSP temporarily disabled for mobile development testing -->
+    <!-- <meta http-equiv="Content-Security-Policy" content="
+      default-src 'self' http://10.0.2.2:* http://localhost:*; 
       script-src 'self' 'unsafe-inline' 'unsafe-eval' 
+        http://10.0.2.2:* http://localhost:*
         https://www.googletagmanager.com 
         https://www.gstatic.com 
         https://*.firebaseio.com 
         https://*.googleapis.com; 
       style-src 'self' 'unsafe-inline' 
+        http://10.0.2.2:* http://localhost:*
         https://fonts.googleapis.com; 
       font-src 'self' 
+        http://10.0.2.2:* http://localhost:*
         https://fonts.gstatic.com 
         data:; 
       img-src 'self' 
+        http://10.0.2.2:* http://localhost:*
         https://*.googleapis.com 
         https://*.firebaseapp.com 
         https://firebasestorage.googleapis.com 
         data: 
         blob:; 
       connect-src 'self' 
+        http://10.0.2.2:* http://localhost:*
         https://*.firebaseio.com 
         https://*.googleapis.com 
         https://*.firebaseapp.com 
         https://www.google-analytics.com 
         wss://*.firebaseio.com; 
       media-src 'self' 
+        http://10.0.2.2:* http://localhost:*
         blob: 
         data:; 
       object-src 'none'; 
       base-uri 'self'; 
       form-action 'self' 
-        https://accounts.google.com; 
-      upgrade-insecure-requests;
-    " />
+        https://accounts.google.com;
+    " /> -->
     <meta
       name="description"
       content="An adult multiplayer sex board game for those with various kinks. Great for solo play, couples or parties. Tailored primarily for men, but accessible by women too."

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     } as any),
   ],
   server: {
+    host: '0.0.0.0', // Allow access from network (including Android emulator)
+    https: false, // Explicitly disable HTTPS
     // Reduce HTTP/2 server push overhead in dev
     fs: {
       allow: ['..'],


### PR DESCRIPTION
## Summary
- Temporarily disable CSP for mobile development testing
- Configure Vite dev server for network access including Android emulator
- Add localhost and emulator host support to CSP directives

## Changes
- **index.html**: Commented out CSP header and added mobile dev host support
- **vite.config.ts**: Added host 0.0.0.0 and explicitly disabled HTTPS

## Test plan
- [ ] Verify dev server accessible from network devices
- [ ] Test app functionality in Android emulator
- [ ] Confirm CSP can be re-enabled for production builds

🤖 Generated with [Claude Code](https://claude.ai/code)