### PR TITLE
Fix syncing bug in which we lose default groups and tiles.

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://blitzed-out.com/</loc>
-    <lastmod>2025-08-18</lastmod>
+    <lastmod>2025-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://blitzed-out.com/PUBLIC</loc>
-    <lastmod>2025-08-18</lastmod>
+    <lastmod>2025-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/context/__tests__/userList.test.tsx
+++ b/src/context/__tests__/userList.test.tsx
@@ -199,7 +199,7 @@ describe('UserListProvider', () => {
       });
 
       // Verify that invalid user data is filtered before updating the store
-      const lastCallArg = mockSetUsers.mock.calls.at(-1)?.[0];
+      const lastCallArg = mockSetUsers.mock.calls[mockSetUsers.mock.calls.length - 1]?.[0];
       expect(lastCallArg).toBeDefined();
       expect(lastCallArg.validUser).toBeDefined();
       expect(lastCallArg.validUser.displayName).toBe('Valid User');

--- a/src/context/migration.tsx
+++ b/src/context/migration.tsx
@@ -1,9 +1,11 @@
-import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import {
   checkMigrationHealth,
   recoverFromFailedMigration,
 } from '@/services/migrationHealthChecker';
+
+import { runSyncRecovery } from '@/services/syncRecoveryService';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Context value interface for migration state management.
@@ -211,6 +213,7 @@ export function MigrationProvider({ children }: MigrationProviderProps) {
     setError(null);
 
     try {
+      await runSyncRecovery();
       const migrationService = await loadMigrationService();
       const success = await migrationService.runMigrationIfNeeded();
 

--- a/src/services/__tests__/migrationService.test.ts
+++ b/src/services/__tests__/migrationService.test.ts
@@ -55,7 +55,7 @@ vi.mock('@/locales/en/translation.json', () => ({
 describe('Migration Service', () => {
   const MIGRATION_KEY = 'blitzed-out-action-groups-migration';
   const BACKGROUND_MIGRATION_KEY = 'blitzed-out-background-migration';
-  const MIGRATION_VERSION = '2.2.0';
+  const MIGRATION_VERSION = '2.3.0';
 
   beforeEach(() => {
     // Set up localStorage mock

--- a/src/services/__tests__/syncRecoveryService.test.ts
+++ b/src/services/__tests__/syncRecoveryService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   forceRecovery,
   resetRecoveryStatus,
@@ -23,6 +23,10 @@ describe('syncRecoveryService', () => {
     // Mock console methods
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   describe('runSyncRecovery', () => {

--- a/src/services/__tests__/syncRecoveryService.test.ts
+++ b/src/services/__tests__/syncRecoveryService.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  forceRecovery,
+  resetRecoveryStatus,
+  runSyncRecovery,
+  wasUserAffectedBySync,
+} from '../syncRecoveryService';
+
+import { forceFreshMigration } from '@/services/migrationService';
+import { getCustomGroups } from '@/stores/customGroups';
+import { getTiles } from '@/stores/customTiles';
+
+// Mock dependencies
+vi.mock('@/stores/customTiles');
+vi.mock('@/stores/customGroups');
+vi.mock('@/services/migrationService');
+
+describe('syncRecoveryService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRecoveryStatus();
+
+    // Mock console methods
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('runSyncRecovery', () => {
+    it('should detect corruption and trigger recovery when database is corrupted', async () => {
+      // Mock corrupted database state
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
+        if (filters?.isDefault === true) return []; // No default groups!
+        return [];
+      });
+
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters === undefined || Object.keys(filters).length === 0) return []; // Very few tiles
+        if (filters?.isCustom === 0 && filters?.isEnabled === 1) return []; // No enabled defaults
+        return [];
+      });
+
+      vi.mocked(forceFreshMigration).mockResolvedValue();
+
+      const result = await runSyncRecovery();
+
+      expect(result).toBe(true);
+      expect(forceFreshMigration).toHaveBeenCalled();
+    });
+
+    it('should not trigger recovery when database is healthy', async () => {
+      // Mock healthy database state
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
+        if (filters?.isDefault === true) return [{ id: '1' }, { id: '2' }] as any; // Has default groups
+        return [];
+      });
+
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters === undefined || Object.keys(filters).length === 0) {
+          // Return a realistic number of tiles
+          return Array.from({ length: 200 }, (_, i) => ({ id: i })) as any;
+        }
+        if (filters?.isCustom === 0 && filters?.isEnabled === 1) {
+          return Array.from({ length: 180 }, (_, i) => ({ id: i })) as any; // Many enabled defaults
+        }
+        return [];
+      });
+
+      const result = await runSyncRecovery();
+
+      expect(result).toBe(false);
+      expect(forceFreshMigration).not.toHaveBeenCalled();
+    });
+
+    it('should not run recovery twice for the same version', async () => {
+      // First run with corrupted state
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(forceFreshMigration).mockResolvedValue();
+
+      // First run should trigger recovery
+      const firstRun = await runSyncRecovery();
+      expect(firstRun).toBe(true);
+      expect(forceFreshMigration).toHaveBeenCalledTimes(1);
+
+      // Second run should skip recovery
+      const secondRun = await runSyncRecovery();
+      expect(secondRun).toBe(false);
+      expect(forceFreshMigration).toHaveBeenCalledTimes(1); // Still only once
+    });
+
+    it('should handle detection errors gracefully', async () => {
+      vi.mocked(getCustomGroups).mockRejectedValue(new Error('Database error'));
+
+      const result = await runSyncRecovery();
+
+      expect(result).toBe(false);
+      expect(forceFreshMigration).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('[Sync Recovery] Error detecting corruption:'),
+        expect.any(Error)
+      );
+    });
+
+    it('should handle recovery errors gracefully', async () => {
+      // Mock corrupted state
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(getTiles).mockResolvedValue([]);
+
+      // Mock migration failure
+      vi.mocked(forceFreshMigration).mockRejectedValue(new Error('Migration failed'));
+
+      const result = await runSyncRecovery();
+
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('[Sync Recovery] Error during recovery:'),
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('corruption detection logic', () => {
+    it('should identify corruption with multiple indicators', async () => {
+      // Mock state with multiple corruption indicators
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
+        if (filters?.isDefault === true) return []; // Indicator 1: No default groups
+        return [];
+      });
+
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters === undefined || Object.keys(filters).length === 0) return []; // Indicator 2: Very few tiles
+        if (filters?.isCustom === 0 && filters?.isEnabled === 1) return []; // Indicator 3: No enabled defaults
+        return [];
+      });
+
+      vi.mocked(forceFreshMigration).mockResolvedValue();
+
+      const result = await runSyncRecovery();
+      expect(result).toBe(true);
+    });
+
+    it('should not trigger recovery with only one indicator', async () => {
+      // Mock state with only one indicator
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
+        if (filters?.isDefault === true) return [{ id: '1' }] as any; // Has default groups
+        return [];
+      });
+
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters === undefined || Object.keys(filters).length === 0) return []; // Only this indicator
+        if (filters?.isCustom === 0 && filters?.isEnabled === 1) {
+          return Array.from({ length: 100 }, (_, i) => ({ id: i })) as any; // Has enabled defaults
+        }
+        return [];
+      });
+
+      const result = await runSyncRecovery();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('wasUserAffectedBySync', () => {
+    it('should return true if user was affected by sync bug', async () => {
+      // Trigger recovery with corruption
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(forceFreshMigration).mockResolvedValue();
+
+      await runSyncRecovery();
+
+      expect(wasUserAffectedBySync()).toBe(true);
+    });
+
+    it('should return false if user was not affected', async () => {
+      // Healthy database state
+      vi.mocked(getCustomGroups).mockResolvedValue([{ id: '1' }] as any);
+      vi.mocked(getTiles).mockResolvedValue(
+        Array.from({ length: 200 }, (_, i) => ({ id: i })) as any
+      );
+
+      await runSyncRecovery();
+
+      expect(wasUserAffectedBySync()).toBe(false);
+    });
+  });
+
+  describe('forceRecovery', () => {
+    it('should force recovery even if already performed', async () => {
+      // First run
+      vi.mocked(getCustomGroups).mockResolvedValue([{ id: '1' }] as any);
+      vi.mocked(getTiles).mockResolvedValue([{ id: '1' }] as any);
+      await runSyncRecovery();
+
+      // Force recovery should reset status and run again
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(forceFreshMigration).mockResolvedValue();
+
+      const result = await forceRecovery();
+
+      expect(result).toBe(true);
+      expect(forceFreshMigration).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/__tests__/syncService.test.ts
+++ b/src/services/__tests__/syncService.test.ts
@@ -1,0 +1,631 @@
+import {
+  addCustomTile,
+  deleteAllIsCustomTiles,
+  getTiles,
+  updateCustomTile,
+} from '@/stores/customTiles';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteCustomGroup, getCustomGroups, importCustomGroups } from '@/stores/customGroups';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import {
+  syncCustomGroupsToFirebase,
+  syncCustomTilesToFirebase,
+  syncDataFromFirebase,
+} from '../syncService';
+
+import { getAuth } from 'firebase/auth';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+// Override the global sync service mock for this test file
+vi.mock('@/services/syncService', async () => {
+  const actual = await vi.importActual('@/services/syncService');
+  return actual;
+});
+
+// Mock Firebase
+vi.mock('firebase/auth');
+vi.mock('firebase/firestore');
+
+// Mock stores
+vi.mock('@/stores/customTiles');
+vi.mock('@/stores/customGroups');
+vi.mock('@/stores/gameBoard');
+vi.mock('@/stores/settingsStore');
+
+describe('syncService', () => {
+  const mockUser = { uid: 'test-user-123', isAnonymous: false };
+  const mockAuth = { currentUser: mockUser };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getAuth).mockReturnValue(mockAuth as any);
+
+    // Mock Firestore doc to return a proper document reference
+    vi.mocked(doc).mockReturnValue({
+      id: 'test-user-123',
+      path: 'user-data/test-user-123',
+    } as any);
+  });
+
+  describe('syncCustomTilesToFirebase', () => {
+    it('should sync both custom tiles and disabled defaults to Firebase', async () => {
+      const mockCustomTiles = [
+        {
+          id: 1,
+          group: 'custom-group',
+          intensity: 1,
+          action: 'Custom action',
+          tags: [],
+          isEnabled: 1,
+          isCustom: 1,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ];
+
+      const mockDisabledDefaults = [
+        {
+          id: 2,
+          group: 'teasing',
+          intensity: 1,
+          action: 'Default action',
+          tags: [],
+          isEnabled: 0, // User disabled this default action
+          isCustom: 0,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ];
+
+      // Mock getTiles to return different results based on filters
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters?.isCustom === 1) return mockCustomTiles;
+        if (filters?.isCustom === 0 && filters?.isEnabled === 0) return mockDisabledDefaults;
+        return [];
+      });
+
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      const result = await syncCustomTilesToFirebase();
+
+      expect(result).toBe(true);
+      expect(getTiles).toHaveBeenCalledWith({ isCustom: 1 });
+      expect(getTiles).toHaveBeenCalledWith({ isCustom: 0, isEnabled: 0 });
+      expect(setDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          customTiles: mockCustomTiles,
+          disabledDefaults: mockDisabledDefaults,
+          lastUpdated: expect.any(Date),
+        }),
+        { merge: true }
+      );
+    });
+
+    it('should handle when no disabled defaults exist', async () => {
+      const mockCustomTiles = [
+        {
+          id: 1,
+          group: 'custom-group',
+          intensity: 1,
+          action: 'Custom action',
+          tags: [],
+          isEnabled: 1,
+          isCustom: 1,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ];
+
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters?.isCustom === 1) return mockCustomTiles;
+        if (filters?.isCustom === 0 && filters?.isEnabled === 0) return [];
+        return [];
+      });
+
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      const result = await syncCustomTilesToFirebase();
+
+      expect(result).toBe(true);
+      expect(setDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          customTiles: mockCustomTiles,
+          disabledDefaults: [],
+          lastUpdated: expect.any(Date),
+        }),
+        { merge: true }
+      );
+    });
+
+    it('should return false when user is not logged in', async () => {
+      vi.mocked(getAuth).mockReturnValue({ currentUser: null } as any);
+
+      const result = await syncCustomTilesToFirebase();
+
+      expect(result).toBe(false);
+      expect(getTiles).not.toHaveBeenCalled();
+      expect(setDoc).not.toHaveBeenCalled();
+    });
+
+    it('should handle Firebase errors gracefully', async () => {
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(setDoc).mockRejectedValue(new Error('Firebase error'));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await syncCustomTilesToFirebase();
+
+      expect(result).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith('Error syncing custom tiles:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('syncDataFromFirebase', () => {
+    const mockFirebaseData = {
+      customTiles: [
+        {
+          id: 1,
+          group: 'custom-group',
+          intensity: 1,
+          action: 'Custom action',
+          tags: [],
+          isEnabled: 1,
+          isCustom: 1,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ],
+      disabledDefaults: [
+        {
+          id: 2,
+          group: 'teasing',
+          intensity: 1,
+          action: 'Default action',
+          tags: [],
+          isEnabled: 0,
+          isCustom: 0,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ],
+      customGroups: [],
+      gameBoards: [],
+      settings: {},
+    };
+
+    beforeEach(() => {
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockFirebaseData,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+      vi.mocked(deleteAllIsCustomTiles).mockResolvedValue(true);
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(addCustomTile).mockResolvedValue(1);
+      vi.mocked(updateCustomTile).mockResolvedValue(1);
+      vi.mocked(deleteCustomGroup).mockResolvedValue(undefined);
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(importCustomGroups).mockResolvedValue(undefined);
+      vi.mocked(useSettingsStore.getState).mockReturnValue({
+        updateSettings: vi.fn(),
+      } as any);
+    });
+
+    it('should restore both custom tiles and disabled defaults from Firebase', async () => {
+      // Mock getTiles to handle different scenarios
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        // For custom tiles duplication check - return empty (no existing duplicates)
+        if (
+          filters?.gameMode === 'online' &&
+          filters?.group === 'custom-group' &&
+          filters?.action === 'Custom action'
+        ) {
+          return [];
+        }
+        // For disabled defaults matching - return existing default tile
+        if (
+          filters?.gameMode === 'online' &&
+          filters?.group === 'teasing' &&
+          filters?.action === 'Default action'
+        ) {
+          return [{ id: 100, isEnabled: 1, isCustom: 0 }] as any;
+        }
+        return [];
+      });
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+
+      // Should clear existing custom tiles
+      expect(deleteAllIsCustomTiles).toHaveBeenCalled();
+
+      // Should import custom tiles (no duplicates found)
+      expect(addCustomTile).toHaveBeenCalledWith(mockFirebaseData.customTiles[0]);
+
+      // Should apply disabled defaults to existing default tiles (not add new ones)
+      expect(updateCustomTile).toHaveBeenCalledWith(100, { isEnabled: 0 });
+    });
+
+    it('should handle case where disabled defaults are not in Firebase data', async () => {
+      const mockDataWithoutDisabled = {
+        ...mockFirebaseData,
+        disabledDefaults: undefined,
+      };
+
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockDataWithoutDisabled,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      // Should still work even without disabled defaults
+      expect(addCustomTile).toHaveBeenCalledTimes(1); // Only custom tiles
+    });
+
+    it('should handle empty custom tiles gracefully', async () => {
+      const mockDataEmpty = {
+        ...mockFirebaseData,
+        customTiles: [],
+        disabledDefaults: [],
+      };
+
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockDataEmpty,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      expect(deleteAllIsCustomTiles).toHaveBeenCalled();
+      expect(addCustomTile).not.toHaveBeenCalled();
+    });
+
+    it('should return false when user document does not exist', async () => {
+      const mockDoc = {
+        exists: () => false,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(false);
+      expect(deleteAllIsCustomTiles).not.toHaveBeenCalled();
+    });
+
+    it('should return false when user is not logged in', async () => {
+      vi.mocked(getAuth).mockReturnValue({ currentUser: null } as any);
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(false);
+      expect(getDoc).not.toHaveBeenCalled();
+    });
+
+    it('should handle Firebase read errors gracefully', async () => {
+      vi.mocked(getDoc).mockRejectedValue(new Error('Firebase read error'));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith('Error syncing data:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should use surgical approach to preserve default content', async () => {
+      // Mock existing disabled defaults that need to be reset before applying Firebase data
+      const mockExistingDisabled = [
+        {
+          id: 3,
+          group: 'teasing',
+          intensity: 1,
+          action: 'Some old disabled action',
+          tags: [],
+          isEnabled: 0,
+          isCustom: 0,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ];
+
+      // Mock user-created groups that should be cleared
+      const mockUserGroups = [
+        {
+          id: 1,
+          title: 'My Custom Group',
+          isDefault: false,
+          locale: 'en',
+        },
+      ];
+
+      // Mock getTiles calls for different scenarios
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters?.isCustom === 0 && filters?.isEnabled === 0) return mockExistingDisabled;
+        if (filters?.gameMode && filters?.group && filters?.intensity && filters?.action) {
+          // For applyDisabledDefaults - finding matching tiles
+          return [{ id: 4, isEnabled: 1, isCustom: 0 }] as any;
+        }
+        return [];
+      });
+
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
+        if (filters?.isDefault === false) return mockUserGroups as any;
+        return [];
+      });
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+
+      // Verify surgical approach: only custom tiles cleared (preserves defaults)
+      expect(deleteAllIsCustomTiles).toHaveBeenCalled();
+
+      // Verify surgical approach: only user groups cleared (preserves default groups)
+      expect(deleteCustomGroup).toHaveBeenCalledWith(mockUserGroups[0].id);
+
+      // Verify disabled defaults were reset to enabled before applying Firebase data
+      expect(updateCustomTile).toHaveBeenCalledWith(mockExistingDisabled[0].id, { isEnabled: 1 });
+
+      // Verify Firebase disabled defaults are applied to matching default tiles
+      expect(updateCustomTile).toHaveBeenCalledWith(4, { isEnabled: 0 });
+    });
+
+    it('should preserve user disabled actions during sync', async () => {
+      // Test the core bug: user disables a default action, logs out, logs back in
+      // The disabled action should be preserved, not reset to enabled
+
+      // Mock existing default tile that matches the disabled default from Firebase
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters?.gameMode && filters?.group && filters?.intensity && filters?.action) {
+          // For applyDisabledDefaults - finding matching tiles
+          return [{ id: 200, isEnabled: 1, isCustom: 0 }] as any;
+        }
+        return [];
+      });
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+
+      // Verify that the disabled default action state is applied to existing default tile
+      expect(updateCustomTile).toHaveBeenCalledWith(200, { isEnabled: 0 });
+    });
+
+    it('should handle missing disabledDefaults field in Firebase data gracefully', async () => {
+      // Test backward compatibility - older Firebase data without disabledDefaults
+      const mockDataWithoutDisabled = {
+        customTiles: mockFirebaseData.customTiles,
+        customGroups: mockFirebaseData.customGroups,
+        // No disabledDefaults field
+      };
+
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockDataWithoutDisabled,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      // Should not call any disabled defaults functions when the field doesn't exist
+      expect(updateCustomTile).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty disabledDefaults array correctly', async () => {
+      const mockDataWithEmptyDisabled = {
+        ...mockFirebaseData,
+        disabledDefaults: [],
+      };
+
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockDataWithEmptyDisabled,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+
+      // Mock existing disabled defaults that should be reset
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters?.isCustom === 0 && filters?.isEnabled === 0) {
+          return [{ id: 5, isEnabled: 0, isCustom: 0 }] as any;
+        }
+        return [];
+      });
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      // Should reset existing disabled defaults even if Firebase has none
+      expect(updateCustomTile).toHaveBeenCalledWith(5, { isEnabled: 1 });
+    });
+  });
+
+  describe('syncCustomGroupsToFirebase', () => {
+    it('should sync only user-created groups, not default groups', async () => {
+      const mockUserGroups = [
+        {
+          id: 1,
+          title: 'My Custom Group',
+          isDefault: false,
+          locale: 'en',
+        },
+        {
+          id: 2,
+          title: 'Another Custom Group',
+          isDefault: false,
+          locale: 'en',
+        },
+      ];
+
+      // Mock getCustomGroups to return user groups when isDefault: false filter is applied
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
+        if (filters?.isDefault === false) return mockUserGroups as any;
+        return [];
+      });
+
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      const result = await syncCustomGroupsToFirebase();
+
+      expect(result).toBe(true);
+      expect(getCustomGroups).toHaveBeenCalledWith({ isDefault: false });
+      expect(setDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          customGroups: mockUserGroups,
+          lastUpdated: expect.any(Date),
+        }),
+        { merge: true }
+      );
+    });
+
+    it('should handle empty user groups correctly', async () => {
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      const result = await syncCustomGroupsToFirebase();
+
+      expect(result).toBe(true);
+      expect(setDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          customGroups: [],
+          lastUpdated: expect.any(Date),
+        }),
+        { merge: true }
+      );
+    });
+
+    it('should return false when user is not logged in', async () => {
+      vi.mocked(getAuth).mockReturnValue({ currentUser: null } as any);
+
+      const result = await syncCustomGroupsToFirebase();
+
+      expect(result).toBe(false);
+      expect(getCustomGroups).not.toHaveBeenCalled();
+    });
+
+    it('should handle Firebase errors gracefully', async () => {
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(setDoc).mockRejectedValue(new Error('Firebase error'));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await syncCustomGroupsToFirebase();
+
+      expect(result).toBe(false);
+      expect(consoleSpy).toHaveBeenCalledWith('Error syncing custom groups:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should handle complete login workflow without data loss', async () => {
+      // Simulate user workflow:
+      // 1. User disables some default actions
+      // 2. User creates custom actions
+      // 3. User logs out and logs back in
+      // 4. All actions should be preserved
+
+      const mockCustomTiles = [
+        {
+          id: 1,
+          group: 'custom-group',
+          intensity: 1,
+          action: 'User created action',
+          tags: [],
+          isEnabled: 1,
+          isCustom: 1,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ];
+
+      const mockDisabledDefaults = [
+        {
+          id: 2,
+          group: 'teasing',
+          intensity: 1,
+          action: 'User disabled this default',
+          tags: [],
+          isEnabled: 0,
+          isCustom: 0,
+          locale: 'en',
+          gameMode: 'online',
+        },
+      ];
+
+      // Mock the upload (when user logs out)
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        if (filters?.isCustom === 1) return mockCustomTiles;
+        if (filters?.isCustom === 0 && filters?.isEnabled === 0) return mockDisabledDefaults;
+        return [];
+      });
+
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      // Test upload
+      const uploadResult = await syncCustomTilesToFirebase();
+      expect(uploadResult).toBe(true);
+
+      // Mock the download (when user logs back in)
+      const mockFirebaseData = {
+        customTiles: mockCustomTiles,
+        disabledDefaults: mockDisabledDefaults,
+      };
+
+      const mockDoc = {
+        exists: () => true,
+        data: () => mockFirebaseData,
+      };
+      vi.mocked(getDoc).mockResolvedValue(mockDoc as any);
+      vi.mocked(deleteAllIsCustomTiles).mockResolvedValue(true);
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(addCustomTile).mockResolvedValue(1);
+
+      // Mock getTiles for the download test
+      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
+        // For custom tiles duplication check - return empty (no existing duplicates)
+        if (
+          filters?.gameMode === 'online' &&
+          filters?.group === 'custom-group' &&
+          filters?.action === 'User created action'
+        ) {
+          return [];
+        }
+        // For disabled defaults matching - return existing default tile
+        if (
+          filters?.gameMode === 'online' &&
+          filters?.group === 'teasing' &&
+          filters?.action === 'User disabled this default'
+        ) {
+          return [{ id: 300, isEnabled: 1, isCustom: 0 }] as any;
+        }
+        return [];
+      });
+
+      // Test download
+      const downloadResult = await syncDataFromFirebase();
+      expect(downloadResult).toBe(true);
+
+      // Verify custom tiles are restored
+      expect(addCustomTile).toHaveBeenCalledWith(mockCustomTiles[0]);
+
+      // Verify disabled defaults are applied to existing default tiles
+      expect(updateCustomTile).toHaveBeenCalledWith(300, { isEnabled: 0 });
+    });
+  });
+});

--- a/src/services/__tests__/syncService.test.ts
+++ b/src/services/__tests__/syncService.test.ts
@@ -11,7 +11,7 @@ import {
   syncCustomGroupsToFirebase,
   syncCustomTilesToFirebase,
   syncDataFromFirebase,
-} from '../syncService';
+} from '@/services/syncService';
 
 import { getAuth } from 'firebase/auth';
 import { useSettingsStore } from '@/stores/settingsStore';

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -317,7 +317,6 @@ export async function wipeAllAppData(): Promise<void> {
     try {
       const { default: db } = await import('@/stores/store');
       await db.delete();
-      console.log('Successfully cleared IndexedDB');
     } catch (error) {
       console.warn('Failed to clear IndexedDB:', error);
     }
@@ -369,11 +368,7 @@ export async function wipeAllAppData(): Promise<void> {
           // Silently continue
         }
       });
-
-      console.log(`Attempted comprehensive clearing of cookie: ${cookieName}`);
     });
-
-    console.log('Successfully wiped all app data');
   } catch (error) {
     console.error('Error wiping app data:', error);
     throw error;

--- a/src/services/migration/constants.ts
+++ b/src/services/migration/constants.ts
@@ -13,9 +13,10 @@ export const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'zh', 'hi'] as const;
 // - 2.1.0: Initial migration system
 // - 2.1.1: Fixed import path matching (@/locales vs /src/locales)
 // - 2.1.2: Added corruption detection and auto-recovery
-// --2.2.0: Added body worship group
+// - 2.2.0: Added body worship group
+// - 2.3.0: Fix syncing issues with custom groups and tiles
 //
-export const MIGRATION_VERSION = '2.2.0';
+export const MIGRATION_VERSION = '2.3.0';
 // ============================================================================
 
 // Configuration keys for localStorage

--- a/src/services/syncRecoveryService.ts
+++ b/src/services/syncRecoveryService.ts
@@ -1,0 +1,148 @@
+/**
+ * Sync Recovery Service
+ *
+ * Detects and recovers from sync service data loss bug.
+ * Runs on app startup to identify users with corrupted local databases
+ * and trigger recovery through migration system.
+ */
+
+import { forceFreshMigration } from '@/services/migrationService';
+import { getCustomGroups } from '@/stores/customGroups';
+import { getTiles } from '@/stores/customTiles';
+import { safeLocalStorage } from '@/services/migration/errorHandling';
+
+// Recovery tracking
+const RECOVERY_STATUS_KEY = 'blitzed-out-sync-recovery-status';
+const RECOVERY_VERSION = '1.0.0';
+
+interface RecoveryStatus {
+  version: string;
+  recoveryPerformed: boolean;
+  detectedCorruption: boolean;
+  recoveryTimestamp: number;
+}
+
+/**
+ * Main recovery function - call this on app startup
+ */
+export async function runSyncRecovery(): Promise<boolean> {
+  try {
+    // Check if recovery already performed for this version
+    const recoveryStatus = getRecoveryStatus();
+    if (recoveryStatus?.recoveryPerformed && recoveryStatus?.version === RECOVERY_VERSION) {
+      return false; // Recovery already done
+    }
+
+    // Detect corruption
+    const isCorrupted = await detectDatabaseCorruption();
+
+    if (isCorrupted) {
+      // Force fresh migration to rebuild everything
+      await forceFreshMigration();
+
+      // Mark recovery as completed
+      markRecoveryCompleted(true);
+      return true;
+    } else {
+      // Mark recovery as checked (no corruption found)
+      markRecoveryCompleted(false);
+      return false;
+    }
+  } catch (error) {
+    console.error('[Sync Recovery] Error during recovery:', error);
+    return false;
+  }
+}
+
+/**
+ * Detect if local database is corrupted by sync bug
+ */
+async function detectDatabaseCorruption(): Promise<boolean> {
+  try {
+    // Check 1: No default groups exist (major red flag)
+    const defaultGroups = await getCustomGroups({ isDefault: true });
+    const hasDefaultGroups = defaultGroups.length > 0;
+
+    // Check 2: Very few total actions (likely only custom ones remain)
+    const allTiles = await getTiles({});
+    const totalTileCount = allTiles.length;
+
+    // Check 3: No enabled default actions (everything was nuked)
+    const enabledDefaults = await getTiles({ isCustom: 0, isEnabled: 1 });
+    const hasEnabledDefaults = enabledDefaults.length > 0;
+
+    // Corruption indicators
+    const corruptionIndicators = {
+      noDefaultGroups: !hasDefaultGroups,
+      fewTotalActions: totalTileCount < 50, // Should have hundreds of default actions
+      noEnabledDefaults: !hasEnabledDefaults,
+    };
+
+    const corruptionScore = Object.values(corruptionIndicators).filter(Boolean).length;
+
+    // Analysis for debugging in development
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[Sync Recovery] Corruption analysis:', {
+        defaultGroups: defaultGroups.length,
+        totalTiles: totalTileCount,
+        enabledDefaults: enabledDefaults.length,
+        indicators: corruptionIndicators,
+        score: corruptionScore,
+      });
+    }
+
+    // If 2 or more indicators, likely corrupted
+    return corruptionScore >= 2;
+  } catch (error) {
+    console.error('[Sync Recovery] Error detecting corruption:', error);
+    return false; // Don't trigger recovery if we can't detect properly
+  }
+}
+
+/**
+ * Get recovery status from localStorage
+ */
+function getRecoveryStatus(): RecoveryStatus | null {
+  try {
+    return safeLocalStorage.getJSON<RecoveryStatus>(RECOVERY_STATUS_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mark recovery as completed
+ */
+function markRecoveryCompleted(detectedCorruption: boolean): void {
+  const status: RecoveryStatus = {
+    version: RECOVERY_VERSION,
+    recoveryPerformed: true,
+    detectedCorruption,
+    recoveryTimestamp: Date.now(),
+  };
+
+  safeLocalStorage.setJSON(RECOVERY_STATUS_KEY, status);
+}
+
+/**
+ * Reset recovery status (for testing)
+ */
+export function resetRecoveryStatus(): void {
+  safeLocalStorage.removeItem(RECOVERY_STATUS_KEY);
+}
+
+/**
+ * Check if user was affected by the sync bug
+ */
+export function wasUserAffectedBySync(): boolean {
+  const status = getRecoveryStatus();
+  return status?.detectedCorruption === true;
+}
+
+/**
+ * Force recovery for testing
+ */
+export async function forceRecovery(): Promise<boolean> {
+  resetRecoveryStatus();
+  return await runSyncRecovery();
+}

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -2,18 +2,19 @@ import {
   addCustomTile,
   deleteAllIsCustomTiles as deleteAllCustomTiles,
   getTiles,
+  updateCustomTile,
 } from '@/stores/customTiles';
-import { deleteAllCustomGroups, getCustomGroups, importCustomGroups } from '@/stores/customGroups';
+import { deleteCustomGroup, getCustomGroups, importCustomGroups } from '@/stores/customGroups';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
 import { getBoards, upsertBoard } from '@/stores/gameBoard';
-import { useSettingsStore } from '@/stores/settingsStore';
 
 import { CustomGroupPull } from '@/types/customGroups';
 import { CustomTilePull } from '@/types/customTiles';
-import { Settings } from '@/types/Settings';
 import { SYNC_DELAY_MS } from '@/constants/actionConstants';
+import { Settings } from '@/types/Settings';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 interface GameBoard {
   title: string;
@@ -27,7 +28,63 @@ interface GameBoard {
 
 const db = getFirestore();
 
-// Sync custom tiles to Firebase
+// Helper function to clear only user-created custom groups (preserve default groups)
+async function clearUserCustomGroups(): Promise<boolean> {
+  try {
+    const userGroups = await getCustomGroups({ isDefault: false });
+    for (const group of userGroups) {
+      await deleteCustomGroup(group.id);
+    }
+    return true;
+  } catch (error) {
+    console.error('Error deleting user custom groups:', error);
+    return false;
+  }
+}
+
+// Helper function to reset disabled defaults back to enabled state before restoring from Firebase
+async function resetDisabledDefaults(): Promise<boolean> {
+  try {
+    const disabledDefaults = await getTiles({ isCustom: 0, isEnabled: 0 });
+    for (const tile of disabledDefaults) {
+      if (tile.id) {
+        // Reset to enabled state - Firebase will restore the correct disabled state
+        await updateCustomTile(tile.id, { isEnabled: 1 });
+      }
+    }
+    return true;
+  } catch (error) {
+    console.error('Error resetting disabled default tiles:', error);
+    return false;
+  }
+}
+
+// Helper function to apply disabled defaults from Firebase to existing default tiles
+async function applyDisabledDefaults(disabledDefaults: CustomTilePull[]): Promise<boolean> {
+  try {
+    for (const disabledTile of disabledDefaults) {
+      // Find the matching default tile in the database
+      const existingTiles = await getTiles({
+        isCustom: 0,
+        gameMode: disabledTile.gameMode,
+        group: disabledTile.group,
+        intensity: disabledTile.intensity,
+        action: disabledTile.action,
+      });
+
+      // If we find a matching default tile, disable it
+      if (existingTiles.length > 0 && existingTiles[0].id) {
+        await updateCustomTile(existingTiles[0].id, { isEnabled: 0 });
+      }
+    }
+    return true;
+  } catch (error) {
+    console.error('Error applying disabled defaults:', error);
+    return false;
+  }
+}
+
+// Sync custom tiles and disabled defaults to Firebase
 export async function syncCustomTilesToFirebase(): Promise<boolean> {
   const auth = getAuth();
   const user = auth.currentUser;
@@ -38,14 +95,18 @@ export async function syncCustomTilesToFirebase(): Promise<boolean> {
   }
 
   try {
-    // Get all custom tiles from Dexie
+    // Get custom tiles (user-created content)
     const customTiles = await getTiles({ isCustom: 1 });
 
-    // Create a document in Firebase with all custom tiles
+    // Get disabled default tiles (user disabled these defaults)
+    const disabledDefaults = await getTiles({ isCustom: 0, isEnabled: 0 });
+
+    // Create a document in Firebase with both custom tiles and disabled defaults
     await setDoc(
       doc(db, 'user-data', user.uid),
       {
         customTiles,
+        disabledDefaults,
         lastUpdated: new Date(),
       },
       { merge: true }
@@ -58,7 +119,7 @@ export async function syncCustomTilesToFirebase(): Promise<boolean> {
   }
 }
 
-// Sync custom groups to Firebase
+// Sync only user-created custom groups to Firebase (NOT default groups)
 export async function syncCustomGroupsToFirebase(): Promise<boolean> {
   const auth = getAuth();
   const user = auth.currentUser;
@@ -69,10 +130,10 @@ export async function syncCustomGroupsToFirebase(): Promise<boolean> {
   }
 
   try {
-    // Get all custom groups from Dexie
-    const customGroups = await getCustomGroups();
+    // Get only user-created custom groups (not default groups)
+    const customGroups = await getCustomGroups({ isDefault: false });
 
-    // Create a document in Firebase with all custom groups
+    // Create a document in Firebase with only user-created custom groups
     await setDoc(
       doc(db, 'user-data', user.uid),
       {
@@ -168,7 +229,7 @@ export async function syncAllDataToFirebase(): Promise<boolean> {
   return true;
 }
 
-// Sync data from Firebase to Dexie
+// Sync data from Firebase to Dexie (SURGICAL APPROACH - preserves default content)
 export async function syncDataFromFirebase(): Promise<boolean> {
   const auth = getAuth();
   const user = auth.currentUser;
@@ -189,9 +250,10 @@ export async function syncDataFromFirebase(): Promise<boolean> {
 
     const userData = userDoc.data();
 
-    // Import custom tiles
+    // SURGICAL APPROACH: Only clear user-created content, preserve defaults
+
+    // 1. Only clear custom tiles (preserve default tiles)
     if (userData.customTiles !== undefined) {
-      // Clear existing custom tiles before importing
       await deleteAllCustomTiles();
 
       // Add a delay after clearing custom tiles before syncing with remote server
@@ -221,10 +283,10 @@ export async function syncDataFromFirebase(): Promise<boolean> {
       }
     }
 
-    // Import custom groups
+    // 2. Only clear user-created custom groups (preserve default groups)
     if (userData.customGroups !== undefined) {
-      // Clear existing custom groups before importing
-      await deleteAllCustomGroups();
+      // Use surgical delete - only removes user-created groups, NOT default groups
+      await clearUserCustomGroups();
 
       // Add a delay after clearing custom groups before syncing with remote server
       await new Promise((resolve) => setTimeout(resolve, SYNC_DELAY_MS));
@@ -239,6 +301,25 @@ export async function syncDataFromFirebase(): Promise<boolean> {
         }
       } else {
         // Firebase data contains empty custom groups array - local database cleared but no new groups to import
+      }
+    }
+
+    // 3. Handle disabled defaults - restore user's disabled state preferences
+    if (userData.disabledDefaults !== undefined) {
+      // First reset all disabled defaults back to enabled
+      await resetDisabledDefaults();
+
+      // Add a delay before applying disabled state
+      await new Promise((resolve) => setTimeout(resolve, SYNC_DELAY_MS));
+
+      // Then apply the disabled state from Firebase
+      if (userData.disabledDefaults && userData.disabledDefaults.length > 0) {
+        try {
+          await applyDisabledDefaults(userData.disabledDefaults as CustomTilePull[]);
+          // Successfully restored user's disabled default action preferences from Firebase
+        } catch (error) {
+          console.error('Error applying disabled defaults:', error);
+        }
       }
     }
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,18 +1,24 @@
-import { afterEach, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+
+import { afterEach, beforeEach, vi } from 'vitest';
+// Configure React Testing Library
+import { cleanup, configure } from '@testing-library/react';
+
+import React from 'react';
 
 // Mock syncService to prevent auth context errors - must be before other imports
 vi.mock('@/services/syncService', () => ({
   syncDataFromFirebase: () => Promise.resolve(true),
+  syncCustomTilesToFirebase: () => Promise.resolve(true),
+  syncCustomGroupsToFirebase: () => Promise.resolve(true),
+  syncGameBoardsToFirebase: () => Promise.resolve(true),
+  syncSettingsToFirebase: () => Promise.resolve(true),
   syncAllDataToFirebase: () => Promise.resolve(true),
   startPeriodicSync: () => {},
   stopPeriodicSync: () => {},
+  isPeriodicSyncActive: () => false,
 }));
 
-import '@testing-library/jest-dom';
-import React from 'react';
-
-// Configure React Testing Library
-import { configure, cleanup } from '@testing-library/react';
 configure({
   testIdAttribute: 'data-testid',
   asyncUtilTimeout: 3000,

--- a/src/types/dexieTypes.ts
+++ b/src/types/dexieTypes.ts
@@ -16,6 +16,7 @@ export interface CustomTileFilters {
   intensity?: string | number | null;
   tag?: string | null;
   isCustom?: number;
+  isEnabled?: number;
   action?: string;
 }
 

--- a/src/views/Cast/index.tsx
+++ b/src/views/Cast/index.tsx
@@ -73,8 +73,7 @@ export default function Cast() {
       videos.forEach((video) => {
         if (video.paused) {
           video.muted = true; // Ensure muted for autoplay policy
-          video.play().catch((error) => {
-            console.log('Video autoplay attempt failed:', error);
+          video.play().catch(() => {
             setNeedsUserInteraction(true);
           });
         }

--- a/src/views/Room/GameBoard/__tests__/index.test.tsx
+++ b/src/views/Room/GameBoard/__tests__/index.test.tsx
@@ -43,7 +43,7 @@ vi.mock('../GameTile', () => ({
 }));
 
 vi.mock('./TokenAnimationLayer', () => ({
-  default: React.forwardRef<any, any>((props, ref) => (
+  default: React.forwardRef<any, any>((_props, ref) => (
     <div data-testid="token-animation-layer" ref={ref}>
       {/* Mock TokenAnimationLayer */}
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic sync recovery on startup for rare data-loss cases.
  * Sync preserves default content while restoring only user-created groups/tiles.
  * Disabled default actions are synchronized across devices.
  * Periodic sync now has a sensible default interval.

* **Bug Fixes**
  * Reduced console noise and improved autoplay fallback prompting users instead of logging.

* **Tests**
  * Added comprehensive tests for sync, recovery, and related flows.

* **Chores**
  * Bumped migration version to 2.3.0; sitemap lastmod updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->