### PR TITLE
fix countdown so the progress bar depletes at 0

### DIFF
--- a/src/components/CountDownButtonModal/index.tsx
+++ b/src/components/CountDownButtonModal/index.tsx
@@ -36,8 +36,6 @@ export default function CountDownButtonModal({
   }
   const { timeLeft, setTimeLeft, togglePause, isPaused } = useCountdown(totalSeconds, true);
 
-  useEffect(() => togglePause(), [togglePause]);
-
   const clickedButton = () => {
     preventParentClose();
     setOpen(true);
@@ -83,7 +81,7 @@ export default function CountDownButtonModal({
             <Box sx={{ position: 'relative', display: 'inline-flex' }}>
               <CircularProgress
                 variant="determinate"
-                value={Math.max(0, Math.min(100, (timeLeft / totalSeconds) * 100))}
+                value={Math.max(0, Math.min(100, ((timeLeft - 1) / (totalSeconds - 1)) * 100))}
                 size={96}
                 thickness={4}
                 color="primary"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Countdown no longer auto-pauses when the modal opens; timers continue as expected.
  * Progress ring now displays a more intuitive progression, starting full and smoothly reaching zero just before completion.
  * Prevents progress values from exceeding bounds, reducing visual glitches and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->