### PR TITLE
Disable sentry submission for just linting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,5 @@ jobs:
       - name: Build project
         if: steps.tests.outcome == 'success'
         run: npm run build
+        env:
+          SENTRY_TELEMETRY: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated continuous integration build configuration to set an environment variable that disables telemetry during the build step.
  - Build and test sequence remains unchanged; builds still proceed only after tests pass.
  - No changes to application functionality, UI, or performance.
  - No impact on release artifacts or versioning.
  - This is an internal maintenance update with no user-facing effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->