### PR TITLE
Add custom tile action preview

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -7,6 +7,9 @@
     "noTilesFound": "No tiles found with the selected filters.",
     "showingTiles": "Showing {{shown}} of {{total}} tiles",
     "gameMode": "Game Mode",
+    "preview": {
+      "title": "Generic preview"
+    },
     "placeholderHelp": {
       "title": "Available Placeholders",
       "description": "Use placeholders to create anatomy-inclusive actions that adapt to each player.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -7,6 +7,9 @@
     "noTilesFound": "No se encontraron fichas con los filtros seleccionados.",
     "showingTiles": "Mostrando {{shown}} de {{total}} fichas",
     "gameMode": "Modo de juego",
+    "preview": {
+      "title": "Vista previa genérica"
+    },
     "placeholderHelp": {
       "title": "Marcadores de Posición Disponibles",
       "description": "Usa marcadores de posición para crear acciones inclusivas de anatomía que se adapten a cada jugador.",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -7,6 +7,9 @@
     "noTilesFound": "Aucune tuile trouvée avec les filtres sélectionnés.",
     "showingTiles": "Affichage de {{shown}} sur {{total}} tuiles",
     "gameMode": "Mode de jeu",
+    "preview": {
+      "title": "Aperçu générique"
+    },
     "placeholderHelp": {
       "title": "Espaces Réservés Disponibles",
       "description": "Utilisez des espaces réservés pour créer des actions inclusives d'anatomie qui s'adaptent à chaque joueur.",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -7,6 +7,9 @@
     "noTilesFound": "चयनित फ़िल्टर के साथ कोई टाइल नहीं मिली।",
     "showingTiles": "{{shown}} में से {{total}} टाइल दिखा रहे हैं",
     "gameMode": "गेम मोड",
+    "preview": {
+      "title": "सामान्य पूर्वावलोकन"
+    },
     "actions": "क्रियाएं",
     "placeholderHelp": {
       "title": "उपलब्ध प्लेसहोल्डर",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -7,6 +7,9 @@
     "noTilesFound": "未找到符合所選篩選條件的磁磚。",
     "showingTiles": "顯示 {{shown}} / {{total}} 磁磚",
     "gameMode": "遊戲模式",
+    "preview": {
+      "title": "通用預覽"
+    },
     "placeholderHelp": {
       "title": "可用的占位符",
       "description": "使用占位符創建適應每個玩家的解剖包容性動作。",

--- a/src/services/__tests__/actionStringReplacement.test.ts
+++ b/src/services/__tests__/actionStringReplacement.test.ts
@@ -41,6 +41,20 @@ describe('actionStringReplacement', () => {
 
       expect(result).toBe('They touches their genitals and chest.');
     });
+
+    it('uses selected gender for anatomy placeholders when provided', () => {
+      const result = actionStringReplacement(
+        '{player} touches {pronoun_possessive} {genital}.',
+        'dom',
+        'TestPlayer',
+        undefined,
+        true,
+        'male',
+        'en'
+      );
+
+      expect(result).toBe('The current player touches his dick.');
+    });
   });
 
   describe('local multiplayer mode', () => {

--- a/src/services/actionStringReplacement.ts
+++ b/src/services/actionStringReplacement.ts
@@ -368,7 +368,14 @@ export default function actionStringReplacement(
     result = result.replace(/{player}/g, PLACEHOLDER_FALLBACKS.player());
     result = result.replace(/{dom}/g, PLACEHOLDER_FALLBACKS.dom());
     result = result.replace(/{sub}/g, PLACEHOLDER_FALLBACKS.sub());
-    result = replaceGenericAnatomyPlaceholders(result, currentLocale);
+
+    if (currentPlayerGender) {
+      const validRole = role === 'sub' || role === 'dom' || role === 'vers' ? role : undefined;
+      result = replaceAnatomyPlaceholders(result, currentPlayerGender, validRole, currentLocale);
+    } else {
+      result = replaceGenericAnatomyPlaceholders(result, currentLocale);
+    }
+
     return capitalizeFirstLetterInCurlyBraces(result);
   }
 

--- a/src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.test.tsx
+++ b/src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.test.tsx
@@ -56,4 +56,23 @@ describe('CustomTilePreview', () => {
     );
     expect(screen.queryByText('{player} follows the {dom}')).not.toBeInTheDocument();
   });
+
+  it('uses the selected anatomy setting in preview output', () => {
+    renderWithoutProviders(
+      <CustomTilePreview
+        action="{player} touches {pronoun_possessive} {genital}"
+        settings={{
+          role: 'dom',
+          displayName: 'Alex',
+          room: 'PUBLIC',
+          boardUpdated: false,
+          gameMode: 'local',
+          gender: 'male',
+          locale: 'en',
+        }}
+      />
+    );
+
+    expect(screen.getByText('The current player touches his dick')).toBeInTheDocument();
+  });
 });

--- a/src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.test.tsx
+++ b/src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.test.tsx
@@ -1,0 +1,59 @@
+import { renderWithoutProviders } from '@/test-utils';
+import { screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as actionReplacementModule from '@/services/actionStringReplacement';
+import CustomTilePreview from './CustomTilePreview';
+
+describe('CustomTilePreview', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not render when the action is empty', () => {
+    renderWithoutProviders(
+      <CustomTilePreview
+        action=""
+        settings={{
+          role: 'sub',
+          displayName: 'Alex',
+          room: 'PUBLIC',
+          boardUpdated: false,
+          gameMode: 'local',
+        }}
+      />
+    );
+
+    expect(screen.queryByText(/preview/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a generic example through actionStringReplacement', () => {
+    const replacementSpy = vi.spyOn(actionReplacementModule, 'default');
+
+    renderWithoutProviders(
+      <CustomTilePreview
+        action="{player} follows the {dom}"
+        settings={{
+          role: 'sub',
+          displayName: 'Alex',
+          room: 'PUBLIC',
+          boardUpdated: false,
+          gameMode: 'local',
+          gender: 'non-binary',
+          locale: 'en',
+        }}
+      />
+    );
+
+    expect(screen.getByText(/customTiles.preview.title/i)).toBeInTheDocument();
+    expect(replacementSpy).toHaveBeenCalledWith(
+      '{player} follows the {dom}',
+      'sub',
+      '',
+      undefined,
+      true,
+      'non-binary',
+      'en'
+    );
+    expect(screen.queryByText('{player} follows the {dom}')).not.toBeInTheDocument();
+  });
+});

--- a/src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.tsx
+++ b/src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.tsx
@@ -1,0 +1,52 @@
+import { Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import actionStringReplacement from '@/services/actionStringReplacement';
+import { Settings } from '@/types/Settings';
+
+interface CustomTilePreviewProps {
+  action: string;
+  settings: Settings;
+}
+
+export default function CustomTilePreview({
+  action,
+  settings,
+}: CustomTilePreviewProps): JSX.Element | null {
+  const { t } = useTranslation();
+  const trimmedAction = action.trim();
+
+  const preview = useMemo(() => {
+    if (!trimmedAction) return '';
+
+    return actionStringReplacement(
+      trimmedAction,
+      settings.role || 'sub',
+      '',
+      undefined,
+      true,
+      settings.gender,
+      settings.locale
+    );
+  }, [trimmedAction, settings.role, settings.gender, settings.locale]);
+
+  if (!trimmedAction) return null;
+
+  return (
+    <Box
+      sx={{
+        px: 1,
+        py: 0.75,
+        mb: 2,
+        borderLeft: 3,
+        borderColor: 'primary.main',
+        bgcolor: 'action.hover',
+      }}
+    >
+      <Typography variant="caption" color="text.secondary">
+        {t('customTiles.preview.title')}
+      </Typography>
+      <Typography variant="body2">{preview}</Typography>
+    </Box>
+  );
+}

--- a/src/views/CustomTileDialog/AddCustomTile/index.tsx
+++ b/src/views/CustomTileDialog/AddCustomTile/index.tsx
@@ -21,6 +21,7 @@ import Accordion from '@/components/Accordion';
 import AccordionDetails from '@/components/Accordion/Details';
 import AccordionSummary from '@/components/Accordion/Summary';
 import CustomGroupDialog from '@/views/CustomGroupDialog';
+import CustomTilePreview from './CustomTilePreview';
 import { CustomGroupPull } from '@/types/customGroups';
 import CustomGroupSelector from '@/components/CustomGroupSelector';
 import { submitCustomAction } from '@/services/firebase';
@@ -431,6 +432,8 @@ export default function AddCustomTile({
                 }
               }}
             />
+
+            <CustomTilePreview action={localTileData.action} settings={settings} />
 
             {/* Placeholder Help Section */}
             <Box sx={{ mb: 2 }}>


### PR DESCRIPTION
## Summary
- Add a live custom tile preview using the same actionStringReplacement path as board rendering
- Show the preview directly below the custom tile action field
- Add focused tests for empty and placeholder-rendered preview states

## Tests
- npm test -- run src/views/CustomTileDialog/AddCustomTile/CustomTilePreview.test.tsx
- npm run type-check