### PR TITLE
refactor: loose coupling — extract hooks, shared utilities, and deepen module contracts

### DIFF
--- a/src/components/TurnIndicator/index.tsx
+++ b/src/components/TurnIndicator/index.tsx
@@ -1,5 +1,5 @@
 import ToastAlert from '@/components/ToastAlert';
-import latestMessageByType, { latestMessage } from '@/helpers/messages';
+import { latestMessageByType, latestMessage } from '@/helpers/messages';
 import { useSettings } from '@/stores/settingsStore';
 import useMessages from '@/context/hooks/useMessages';
 import useTurnIndicator from '@/hooks/useTurnIndicator';

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,14 +1,13 @@
-import React, { useEffect, useMemo, useState, useRef, ReactNode, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, ReactNode } from 'react';
 import { User } from '@/types';
 import { getErrorMessage } from '@/types/errors';
 import { registerSyncProvider } from '@/services/authBridge';
 import { reportFirefoxMobileAuthError } from '@/utils/firefoxMobileReporting';
 import { loadFirebase, preloadFirebase } from '@/utils/lazyFirebase';
+import { useAuthSync } from '@/hooks/useAuthSync';
+import type { SyncStatus } from '@/hooks/useAuthSync';
 
-export interface SyncStatus {
-  syncing: boolean;
-  lastSync: Date | null;
-}
+export type { SyncStatus };
 
 export interface AuthContextType {
   user: User | null;
@@ -40,48 +39,15 @@ interface AuthProviderProps {
 
 function AuthProvider(props: AuthProviderProps): JSX.Element {
   const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState<boolean>(false); // Changed: false by default for immediate UI
-  const [initializing, setInitializing] = useState<boolean>(true); // New: tracks initial auth check
+  const [loading, setLoading] = useState<boolean>(false);
+  const [initializing, setInitializing] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
-  const [syncStatus, setSyncStatus] = useState<SyncStatus>({ syncing: false, lastSync: null });
-
-  // Debounce mechanism for sync operations
-  const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const deferTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Track if initial auth check is complete
   const authInitializedRef = useRef<boolean>(false);
 
-  // Function to safely perform sync operations with debouncing
-  const performSync = useCallback(
-    async (syncFunction: () => Promise<boolean>): Promise<boolean> => {
-      // Clear any pending sync timeout
-      if (syncTimeoutRef.current) {
-        clearTimeout(syncTimeoutRef.current);
-        syncTimeoutRef.current = null;
-      }
+  const { syncStatus, syncData, intelligentSync: handleIntelligentSync } = useAuthSync(user);
 
-      // Return early if user is not logged in or is anonymous
-      if (!user || user.isAnonymous) return false;
-
-      try {
-        setSyncStatus({ syncing: true, lastSync: syncStatus.lastSync });
-        await syncFunction();
-        setSyncStatus({ syncing: false, lastSync: new Date() });
-        return true;
-      } catch (err: unknown) {
-        console.error('Sync error:', err);
-        if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError('An unknown error occurred');
-        }
-        setSyncStatus({ syncing: false, lastSync: syncStatus.lastSync });
-        return false;
-      }
-    },
-    [user, syncTimeoutRef, setSyncStatus, syncStatus.lastSync, setError]
-  );
   async function login(displayName = ''): Promise<User | null> {
     try {
       setError(null); // Clear any previous errors
@@ -128,7 +94,6 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
       const loggedInUser = await firebase.loginWithEmail(email, password);
       setUser(loggedInUser);
 
-      // Sync will happen via onAuthStateChanged
       return loggedInUser;
     } catch (err: unknown) {
       const errorMessage = getErrorMessage(err);
@@ -146,7 +111,6 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
       const loggedInUser = await firebase.loginWithGoogle();
       setUser(loggedInUser);
 
-      // Sync will happen via onAuthStateChanged
       return loggedInUser;
     } catch (err: unknown) {
       const errorMessage = getErrorMessage(err);
@@ -192,11 +156,7 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
         const firebase = await loadFirebase();
         const convertedUser = await firebase.convertAnonymousAccount(email, password);
         setUser(convertedUser);
-
-        // Sync local data to Firebase after conversion
-        const { syncAllDataToFirebase } = await import('@/services/syncService');
-        await performSync(syncAllDataToFirebase);
-
+        await syncData();
         return convertedUser;
       } catch (err) {
         if (err instanceof Error) {
@@ -207,7 +167,7 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
         setLoading(false);
       }
     },
-    [setLoading, setUser, performSync, setError]
+    [setLoading, setUser, syncData, setError]
   );
 
   async function updateUser(displayName = ''): Promise<User | null> {
@@ -227,13 +187,9 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
 
   const logoutUser = useCallback(async (): Promise<void> => {
     try {
-      // Sync data to Firebase before logout if user is not anonymous
       if (user && !user.isAnonymous) {
-        // Add timeout to make sure logout doesn't hang
-        const { syncAllDataToFirebase } = await import('@/services/syncService');
-        const syncPromise = performSync(syncAllDataToFirebase);
         const timeoutPromise = new Promise((resolve) => setTimeout(resolve, 5000, false));
-        await Promise.race([syncPromise, timeoutPromise]);
+        await Promise.race([syncData(), timeoutPromise]);
       }
 
       const firebase = await loadFirebase();
@@ -244,7 +200,7 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
       setError(errorMessage);
       throw err;
     }
-  }, [user, performSync, setUser, setError]);
+  }, [user, syncData, setUser, setError]);
 
   const wipeAllAppDataAndReload = useCallback(async (): Promise<void> => {
     try {
@@ -264,117 +220,30 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
     }
   }, [setUser, setError]);
 
-  const syncData = useCallback(async (): Promise<boolean> => {
-    const { syncAllDataToFirebase } = await import('@/services/syncService');
-    return performSync(syncAllDataToFirebase);
-  }, [performSync]);
-
-  const handleIntelligentSync = useCallback(async (): Promise<{
-    success: boolean;
-    conflicts?: string[];
-  }> => {
-    // Don't use performSync wrapper for intelligent sync as it needs custom return type
-    if (!user || user.isAnonymous) {
-      return { success: false, conflicts: ['User not logged in or is anonymous'] };
-    }
-
-    try {
-      setSyncStatus({ syncing: true, lastSync: syncStatus.lastSync });
-      const { intelligentSync } = await import('@/services/syncService');
-      const result = await intelligentSync();
-      setSyncStatus({ syncing: false, lastSync: new Date() });
-      return result;
-    } catch (err: unknown) {
-      console.error('Intelligent sync error:', err);
-      setSyncStatus({ syncing: false, lastSync: syncStatus.lastSync });
-      if (err instanceof Error) {
-        setError(err.message);
-      }
-      return { success: false, conflicts: ['Sync failed due to error'] };
-    }
-  }, [user, syncStatus.lastSync]);
-
   useEffect(() => {
     let unsubscribe: (() => void) | null = null;
     let isSubscribed = true;
 
     const initializeAuth = async () => {
       try {
-        // Load Firebase lazily to initialize it
         await loadFirebase();
         const { getAuth } = await import('firebase/auth');
 
-        if (!isSubscribed) return; // Component unmounted
+        if (!isSubscribed) return;
 
         const auth = getAuth();
-        unsubscribe = auth.onAuthStateChanged(async (userData: User | null) => {
-          if (!isSubscribed) return; // Component unmounted
+        unsubscribe = auth.onAuthStateChanged((userData: User | null) => {
+          if (!isSubscribed) return;
 
           setUser(userData || null);
 
-          // Mark initial auth check as complete
           if (!authInitializedRef.current) {
             authInitializedRef.current = true;
             setInitializing(false);
           }
-
-          // If user is logged in and not anonymous, defer sync operations
-          if (userData && !userData.isAnonymous) {
-            // Defer sync to not block UI rendering - use requestIdleCallback or fallback
-            const deferSync = async () => {
-              // Use debounced sync to prevent multiple rapid syncs
-              if (syncTimeoutRef.current) {
-                clearTimeout(syncTimeoutRef.current);
-              }
-
-              syncTimeoutRef.current = setTimeout(async () => {
-                setSyncStatus({ syncing: true, lastSync: null });
-
-                try {
-                  // Load sync services lazily
-                  const { syncDataFromFirebase, startPeriodicSync } =
-                    await import('@/services/syncService');
-
-                  await syncDataFromFirebase();
-                  setSyncStatus({ syncing: false, lastSync: new Date() });
-
-                  // Start periodic sync after initial sync completes
-                  startPeriodicSync();
-                } catch (err) {
-                  console.error('Error syncing from Firebase:', err);
-                  setSyncStatus({ syncing: false, lastSync: null });
-                } finally {
-                  syncTimeoutRef.current = null;
-                }
-              }, 3000); // Increased delay to 3 seconds to ensure UI is fully loaded first
-            };
-
-            if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
-              (
-                window as Window & {
-                  requestIdleCallback: (
-                    callback: () => void,
-                    options?: { timeout: number }
-                  ) => void;
-                }
-              ).requestIdleCallback(deferSync, { timeout: 10000 });
-            } else {
-              // Fallback for browsers without requestIdleCallback - wait longer to allow UI to fully load
-              deferTimeoutRef.current = setTimeout(deferSync, 5000);
-            }
-          } else {
-            // User is logged out or anonymous, stop periodic sync
-            try {
-              const { stopPeriodicSync } = await import('@/services/syncService');
-              stopPeriodicSync();
-            } catch (err) {
-              console.warn('Could not load sync service to stop periodic sync:', err);
-            }
-          }
         });
       } catch (error) {
         console.error('Failed to initialize Firebase auth:', error);
-        // Mark as initialized even on error to prevent infinite loading
         if (!authInitializedRef.current) {
           authInitializedRef.current = true;
           setInitializing(false);
@@ -382,24 +251,12 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
       }
     };
 
-    // Start Firebase initialization
     initializeAuth();
-
-    // Start preloading Firebase in the background for faster subsequent operations
     preloadFirebase();
 
-    // Clean up function
     return () => {
       isSubscribed = false;
-      if (unsubscribe) {
-        unsubscribe();
-      }
-      if (syncTimeoutRef.current) {
-        clearTimeout(syncTimeoutRef.current);
-      }
-      if (deferTimeoutRef.current) {
-        clearTimeout(deferTimeoutRef.current);
-      }
+      if (unsubscribe) unsubscribe();
     };
   }, []);
 

--- a/src/helpers/__tests__/messages.test.ts
+++ b/src/helpers/__tests__/messages.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterMessages,
+  filterMessagesByType,
+  latestMessage,
+  latestMessageBy,
+  latestMessageByType,
+  normalSortedMessages,
+  orderedMessagesByType,
+  sortedMessages,
+} from '../messages';
+import { Message, MessageType } from '@/types/Message';
+
+const makeMessage = (text: string, type: MessageType, isoDate: string): Message =>
+  ({
+    id: text,
+    text,
+    type,
+    timestamp: isoDate,
+    uid: 'user1',
+    displayName: 'Test',
+  }) as unknown as Message;
+
+const old = makeMessage('old', 'chat', '2024-01-01T00:00:00.000Z');
+const mid = makeMessage('mid', 'chat', '2024-01-02T00:00:00.000Z');
+const recent = makeMessage('recent', 'actions', '2024-01-03T00:00:00.000Z');
+
+describe('normalSortedMessages', () => {
+  it('sorts ASC by timestamp (oldest first)', () => {
+    const result = normalSortedMessages([recent, old, mid]);
+    expect(result.map((m) => m.text)).toEqual(['old', 'mid', 'recent']);
+  });
+
+  it('does not mutate input array', () => {
+    const input = [recent, old, mid];
+    const original = [...input];
+    normalSortedMessages(input);
+    expect(input).toEqual(original);
+  });
+});
+
+describe('sortedMessages', () => {
+  it('reverses to DESC order (newest first)', () => {
+    const result = sortedMessages([old, mid, recent]);
+    expect(result.map((m) => m.text)).toEqual(['recent', 'mid', 'old']);
+  });
+
+  it('does not mutate input array', () => {
+    const input = [old, mid, recent];
+    const copy = [...input];
+    sortedMessages(input);
+    expect(input).toEqual(copy);
+  });
+
+  it('preserves object references (no deep copy)', () => {
+    const input = [old, mid];
+    const result = sortedMessages(input);
+    expect(result[0]).toBe(mid);
+    expect(result[1]).toBe(old);
+  });
+});
+
+describe('filterMessagesByType', () => {
+  it('returns messages matching type', () => {
+    expect(filterMessagesByType([old, mid, recent], 'chat')).toEqual([old, mid]);
+    expect(filterMessagesByType([old, mid, recent], 'actions')).toEqual([recent]);
+  });
+
+  it('returns empty array when none match', () => {
+    expect(filterMessagesByType([old], 'settings')).toEqual([]);
+  });
+
+  it('does not mutate input', () => {
+    const input = [old, mid, recent];
+    const copy = [...input];
+    filterMessagesByType(input, 'chat');
+    expect(input).toEqual(copy);
+  });
+});
+
+describe('filterMessages', () => {
+  it('filters by predicate', () => {
+    const result = filterMessages([old, mid, recent], (m) => m.type === 'chat');
+    expect(result).toEqual([old, mid]);
+  });
+
+  it('returns empty array when predicate matches nothing', () => {
+    expect(filterMessages([old], (m) => m.uid === 'nobody')).toEqual([]);
+  });
+
+  it('preserves object references', () => {
+    const result = filterMessages([old, mid], (m) => m.text === 'old');
+    expect(result[0]).toBe(old);
+  });
+});
+
+describe('orderedMessagesByType', () => {
+  it('ASC order returns oldest first', () => {
+    const result = orderedMessagesByType([mid, old], 'chat', 'ASC');
+    expect(result.map((m) => m.text)).toEqual(['old', 'mid']);
+  });
+
+  it('DESC order returns newest first', () => {
+    const result = orderedMessagesByType([old, mid], 'chat', 'DESC');
+    expect(result.map((m) => m.text)).toEqual(['mid', 'old']);
+  });
+
+  it('filters out non-matching types', () => {
+    const result = orderedMessagesByType([old, mid, recent], 'chat');
+    expect(result.every((m) => m.type === 'chat')).toBe(true);
+    expect(result).toHaveLength(2);
+  });
+
+  it('defaults to ASC', () => {
+    const result = orderedMessagesByType([mid, old], 'chat');
+    expect(result[0].text).toBe('old');
+  });
+});
+
+describe('latestMessageByType', () => {
+  it('returns newest message of given type', () => {
+    expect(latestMessageByType([old, mid, recent], 'chat')).toBe(mid);
+  });
+
+  it('returns undefined when none match', () => {
+    expect(latestMessageByType([old], 'settings')).toBeUndefined();
+  });
+});
+
+describe('latestMessageBy', () => {
+  it('returns newest message matching predicate', () => {
+    const result = latestMessageBy([old, mid, recent], (m) => m.type === 'chat');
+    expect(result).toBe(mid);
+  });
+
+  it('returns undefined when predicate matches nothing', () => {
+    expect(latestMessageBy([old], (m) => m.uid === 'nobody')).toBeUndefined();
+  });
+});
+
+describe('latestMessage', () => {
+  it('returns most recent message', () => {
+    expect(latestMessage([old, mid, recent])).toBe(recent);
+  });
+
+  it('returns undefined for empty array', () => {
+    expect(latestMessage([])).toBeUndefined();
+  });
+});

--- a/src/helpers/getPrivateRoomBackground.ts
+++ b/src/helpers/getPrivateRoomBackground.ts
@@ -1,6 +1,6 @@
 import { Message, RoomMessage } from '@/types/Message';
 
-import latestMessageByType from '@/helpers/messages';
+import { latestMessageByType } from '@/helpers/messages';
 import { processBackground } from '@/services/getBackgroundSource';
 
 type ParsedRoom = {

--- a/src/helpers/messages.ts
+++ b/src/helpers/messages.ts
@@ -1,9 +1,9 @@
 import { Message, MessageType } from '@/types/Message';
 import { parseMessageTimestamp } from '@/helpers/timestamp';
 
-// chat box
+// chat box — non-mutating ASC sort
 export function normalSortedMessages(messages: Message[]): Message[] {
-  return messages.sort((a, b) => {
+  return [...messages].sort((a, b) => {
     const aDate = parseMessageTimestamp(a.timestamp);
     const bDate = parseMessageTimestamp(b.timestamp);
     if (!aDate || !bDate) return 0;
@@ -11,16 +11,23 @@ export function normalSortedMessages(messages: Message[]): Message[] {
   });
 }
 
-// latest on top
+// latest on top — non-mutating DESC (preserves object refs)
 export function sortedMessages(messages: Message[]): Message[] {
-  const newMessage = JSON.parse(JSON.stringify(messages));
-  return newMessage.reverse();
+  return [...messages].reverse();
 }
 
-export default function latestMessageByType(
+export function filterMessagesByType(messages: Message[], type: MessageType): Message[] {
+  return messages.filter((m) => m.type === type);
+}
+
+export function filterMessages(
   messages: Message[],
-  type: MessageType
-): Message | undefined {
+  predicate: (message: Message) => boolean
+): Message[] {
+  return messages.filter(predicate);
+}
+
+export function latestMessageByType(messages: Message[], type: MessageType): Message | undefined {
   return sortedMessages(messages).find((m) => m.type === type);
 }
 

--- a/src/hooks/__tests__/useAuthSync.test.ts
+++ b/src/hooks/__tests__/useAuthSync.test.ts
@@ -1,0 +1,185 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { User } from '@/types';
+import {
+  intelligentSync as intelligentSyncService,
+  startPeriodicSync,
+  stopPeriodicSync,
+  syncAllDataToFirebase,
+  syncDataFromFirebase,
+} from '@/services/syncService';
+import { useAuthSync } from '../useAuthSync';
+
+// Auto-mock — implementations set per-test in beforeEach (resetMocks: true in vitest config)
+vi.mock('@/services/syncService');
+
+const makeUser = (isAnonymous = false): User => ({ uid: 'u1', isAnonymous }) as User;
+
+describe('useAuthSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, 'requestIdleCallback', { value: undefined, writable: true });
+    vi.mocked(syncDataFromFirebase).mockResolvedValue(true);
+    vi.mocked(syncAllDataToFirebase).mockResolvedValue(true);
+    vi.mocked(startPeriodicSync).mockReturnValue(true);
+    vi.mocked(stopPeriodicSync).mockReturnValue(true);
+    vi.mocked(intelligentSyncService).mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with syncing=false and lastSync=null', () => {
+    const { result } = renderHook(() => useAuthSync(null));
+    expect(result.current.syncStatus).toEqual({ syncing: false, lastSync: null });
+  });
+
+  it('does not trigger sync for null user', async () => {
+    renderHook(() => useAuthSync(null));
+    await act(() => vi.advanceTimersByTimeAsync(10_000));
+    expect(syncDataFromFirebase).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger sync for anonymous user', async () => {
+    renderHook(() => useAuthSync(makeUser(true)));
+    await act(() => vi.advanceTimersByTimeAsync(10_000));
+    expect(syncDataFromFirebase).not.toHaveBeenCalled();
+  });
+
+  it('stops periodic sync when user is null', async () => {
+    renderHook(() => useAuthSync(null));
+    await act(() => vi.advanceTimersByTimeAsync(100));
+    expect(stopPeriodicSync).toHaveBeenCalled();
+  });
+
+  it('stops periodic sync when user is anonymous', async () => {
+    renderHook(() => useAuthSync(makeUser(true)));
+    await act(() => vi.advanceTimersByTimeAsync(100));
+    expect(stopPeriodicSync).toHaveBeenCalled();
+  });
+
+  it('triggers syncDataFromFirebase after 5s+3s fallback delay for real user', async () => {
+    renderHook(() => useAuthSync(makeUser()));
+
+    // Before fallback fires
+    await act(() => vi.advanceTimersByTimeAsync(7_999));
+    expect(syncDataFromFirebase).not.toHaveBeenCalled();
+
+    // After 5s fallback + 3s debounce = 8s
+    await act(() => vi.advanceTimersByTimeAsync(1));
+    expect(syncDataFromFirebase).toHaveBeenCalledTimes(1);
+    expect(startPeriodicSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets syncing=false with lastSync after auto-sync completes', async () => {
+    const { result } = renderHook(() => useAuthSync(makeUser()));
+
+    await act(() => vi.advanceTimersByTimeAsync(8_000));
+
+    expect(result.current.syncStatus.syncing).toBe(false);
+    expect(result.current.syncStatus.lastSync).toBeInstanceOf(Date);
+  });
+
+  it('uses requestIdleCallback when available', async () => {
+    const idleCb = vi.fn((cb: () => void) => cb());
+    Object.defineProperty(window, 'requestIdleCallback', { value: idleCb, writable: true });
+
+    renderHook(() => useAuthSync(makeUser()));
+
+    await act(() => vi.advanceTimersByTimeAsync(3_000));
+    expect(idleCb).toHaveBeenCalled();
+    expect(syncDataFromFirebase).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, 'requestIdleCallback', { value: undefined, writable: true });
+  });
+
+  it('syncData calls syncAllDataToFirebase and updates status', async () => {
+    const { result } = renderHook(() => useAuthSync(makeUser()));
+
+    await act(async () => {
+      await result.current.syncData();
+    });
+
+    expect(syncAllDataToFirebase).toHaveBeenCalledTimes(1);
+    expect(result.current.syncStatus.lastSync).toBeInstanceOf(Date);
+  });
+
+  it('syncData returns false for null user without calling service', async () => {
+    const { result } = renderHook(() => useAuthSync(null));
+
+    let returned: boolean;
+    await act(async () => {
+      returned = await result.current.syncData();
+    });
+
+    expect(returned!).toBe(false);
+    expect(syncAllDataToFirebase).not.toHaveBeenCalled();
+  });
+
+  it('syncData returns false for anonymous user', async () => {
+    const { result } = renderHook(() => useAuthSync(makeUser(true)));
+
+    let returned: boolean;
+    await act(async () => {
+      returned = await result.current.syncData();
+    });
+
+    expect(returned!).toBe(false);
+    expect(syncAllDataToFirebase).not.toHaveBeenCalled();
+  });
+
+  it('intelligentSync delegates to syncService and returns result', async () => {
+    const { result } = renderHook(() => useAuthSync(makeUser()));
+
+    let syncResult: { success: boolean; conflicts?: string[] };
+    await act(async () => {
+      syncResult = await result.current.intelligentSync();
+    });
+
+    expect(intelligentSyncService).toHaveBeenCalledTimes(1);
+    expect(syncResult!).toEqual({ success: true });
+  });
+
+  it('intelligentSync returns failure without calling service for null user', async () => {
+    const { result } = renderHook(() => useAuthSync(null));
+
+    let syncResult: { success: boolean; conflicts?: string[] };
+    await act(async () => {
+      syncResult = await result.current.intelligentSync();
+    });
+
+    expect(intelligentSyncService).not.toHaveBeenCalled();
+    expect(syncResult!.success).toBe(false);
+  });
+
+  it('stops sync and clears timers on unmount', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const { unmount } = renderHook(() => useAuthSync(makeUser()));
+    await act(() => vi.advanceTimersByTimeAsync(1_000));
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('user switching from real to null stops periodic sync', async () => {
+    let user: User | null = makeUser();
+    const { rerender } = renderHook(() => useAuthSync(user));
+
+    await act(() => vi.advanceTimersByTimeAsync(8_000));
+
+    vi.clearAllMocks();
+    // Re-set implementations after clearAllMocks
+    vi.mocked(stopPeriodicSync).mockReturnValue(true);
+
+    user = null;
+    rerender();
+
+    await act(() => vi.advanceTimersByTimeAsync(100));
+    expect(stopPeriodicSync).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useSubmitGameSettings.test.ts
+++ b/src/hooks/__tests__/useSubmitGameSettings.test.ts
@@ -1,0 +1,188 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Settings } from '@/types/Settings';
+import type { SubmitContext, SubmitDependencies } from '@/services/gameSettingsOrchestrator';
+import type { User } from '@/types';
+import { submitGameSettings } from '@/services/gameSettingsOrchestrator';
+import { useGameSettingsWiring } from '../useGameSettingsWiring';
+import useSubmitGameSettings from '../useSubmitGameSettings';
+
+vi.mock('@/hooks/useGameSettingsWiring');
+vi.mock('@/services/gameSettingsOrchestrator');
+
+const mockUser: User = { uid: 'u1', displayName: 'Alice', isAnonymous: false } as User;
+
+const mockCtx: SubmitContext = {
+  user: mockUser,
+  currentRoom: 'PUBLIC',
+  currentRoomTileCount: 40,
+  messages: [],
+  gameBoard: undefined,
+  customTiles: [],
+  hasLocalPlayers: false,
+  settingsSnapshot: {} as Settings,
+};
+
+const mockDeps: SubmitDependencies = {
+  updateUser: vi.fn().mockResolvedValue(mockUser),
+  updateGameBoardTiles: vi
+    .fn()
+    .mockResolvedValue({ settingsBoardUpdated: true, gameMode: 'online', newBoard: [] }),
+  sendRoomSettingsFn: vi.fn().mockResolvedValue(undefined),
+  upsertBoardFn: vi.fn().mockResolvedValue(1),
+  sendGameSettingsFn: vi.fn().mockResolvedValue(undefined),
+  createLocalSessionFn: vi.fn().mockResolvedValue(undefined),
+  updateSettingsFn: vi.fn(),
+  navigateFn: vi.fn(),
+  translateFn: vi.fn((k) => k),
+  recordGameStartFn: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockFormData: Settings = {
+  displayName: 'Alice',
+  room: 'PUBLIC',
+  gameMode: 'online',
+} as Settings;
+
+describe('useSubmitGameSettings', () => {
+  beforeEach(() => {
+    vi.mocked(useGameSettingsWiring).mockReturnValue({ ctx: mockCtx, deps: mockDeps });
+    vi.mocked(submitGameSettings).mockResolvedValue(undefined);
+  });
+
+  it('isSubmitting starts false', () => {
+    const { result } = renderHook(() => useSubmitGameSettings());
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('error starts null', () => {
+    const { result } = renderHook(() => useSubmitGameSettings());
+    expect(result.current.error).toBeNull();
+  });
+
+  it('isSubmitting is true during submit then false after success', async () => {
+    let resolveSubmit!: () => void;
+    vi.mocked(submitGameSettings).mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveSubmit = r;
+        })
+    );
+
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    // Start submit but don't await
+    let submitPromise!: Promise<void>;
+    act(() => {
+      submitPromise = result.current.submit(mockFormData, {});
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+
+    await act(async () => {
+      resolveSubmit();
+      await submitPromise;
+    });
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('isSubmitting goes back to false when orchestrator throws', async () => {
+    vi.mocked(submitGameSettings).mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    await act(async () => {
+      await result.current.submit(mockFormData, {}).catch(() => {});
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('sets error when orchestrator throws an Error', async () => {
+    vi.mocked(submitGameSettings).mockRejectedValue(new Error('oops'));
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    await act(async () => {
+      await result.current.submit(mockFormData, {}).catch(() => {});
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('oops');
+  });
+
+  it('wraps non-Error throws as Error("Submission failed")', async () => {
+    vi.mocked(submitGameSettings).mockRejectedValue('raw string');
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    await act(async () => {
+      await result.current.submit(mockFormData, {}).catch(() => {});
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('Submission failed');
+  });
+
+  it('re-throws the error so callers can react', async () => {
+    vi.mocked(submitGameSettings).mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    let caught: Error | undefined;
+    await act(async () => {
+      await result.current.submit(mockFormData, {}).catch((e) => {
+        caught = e;
+      });
+    });
+
+    expect(caught?.message).toBe('boom');
+  });
+
+  it('resets error to null on the next submit', async () => {
+    vi.mocked(submitGameSettings)
+      .mockRejectedValueOnce(new Error('first'))
+      .mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    await act(async () => {
+      await result.current.submit(mockFormData, {}).catch(() => {});
+    });
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => {
+      await result.current.submit(mockFormData, {});
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls submitGameSettings with ctx and deps from wiring', async () => {
+    const actionsList = { someAction: true };
+    const { result } = renderHook(() => useSubmitGameSettings());
+
+    await act(async () => {
+      await result.current.submit(mockFormData, actionsList);
+    });
+
+    expect(submitGameSettings).toHaveBeenCalledWith(
+      mockFormData,
+      actionsList,
+      mockCtx,
+      expect.objectContaining({ navigateFn: mockDeps.navigateFn })
+    );
+  });
+
+  it('overrideDeps replaces specific dep values', async () => {
+    const customNavigate = vi.fn();
+    const { result } = renderHook(() => useSubmitGameSettings({ navigateFn: customNavigate }));
+
+    await act(async () => {
+      await result.current.submit(mockFormData, {});
+    });
+
+    expect(submitGameSettings).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ navigateFn: customNavigate })
+    );
+  });
+});

--- a/src/hooks/__tests__/useTurnTransition.test.ts
+++ b/src/hooks/__tests__/useTurnTransition.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LocalPlayer, LocalSessionSettings } from '@/types';
 import type { Player } from '@/types/player';
 import { getSoundById, playSound } from '@/utils/gameSounds';
-import latestMessageByType from '@/helpers/messages';
+import { latestMessageByType } from '@/helpers/messages';
 import useTurnIndicator from '@/hooks/useTurnIndicator';
 import useMessages from '@/context/hooks/useMessages';
 import { useTurnTransition } from '../useTurnTransition';

--- a/src/hooks/__tests__/useTurnTransition.test.ts
+++ b/src/hooks/__tests__/useTurnTransition.test.ts
@@ -1,0 +1,294 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LocalPlayer, LocalSessionSettings } from '@/types';
+import type { Player } from '@/types/player';
+import { getSoundById, playSound } from '@/utils/gameSounds';
+import latestMessageByType from '@/helpers/messages';
+import useTurnIndicator from '@/hooks/useTurnIndicator';
+import useMessages from '@/context/hooks/useMessages';
+import { useTurnTransition } from '../useTurnTransition';
+
+vi.mock('@/context/hooks/useMessages');
+vi.mock('@/hooks/useTurnIndicator');
+vi.mock('@/helpers/messages');
+vi.mock('@/utils/gameSounds');
+
+const makeLocalPlayer = (name: string, sound?: string): LocalPlayer =>
+  ({ id: name, name, sound: sound ?? '', isActive: true }) as LocalPlayer;
+
+const makeNextPlayer = (isSelf: boolean, displayName = 'Alice'): Player =>
+  ({ uid: 'u1', isSelf, displayName, isFinished: false }) as Player;
+
+const makeMessage = (id = 'msg1') => ({ uid: 'u1', type: 'actions', id }) as any;
+
+const baseInput = {
+  localPlayers: [] as LocalPlayer[],
+  sessionSettings: null as LocalSessionSettings | null,
+  currentPlayerIndex: 0 as number | null | undefined,
+  isLocalPlayerRoom: false,
+  playerDialog: false,
+  othersDialog: false,
+};
+
+describe('useTurnTransition', () => {
+  beforeEach(() => {
+    vi.mocked(useMessages).mockReturnValue({ messages: [] } as any);
+    vi.mocked(latestMessageByType).mockReturnValue(undefined);
+    vi.mocked(useTurnIndicator).mockReturnValue(null);
+    vi.mocked(getSoundById).mockReturnValue(null);
+    vi.mocked(playSound).mockResolvedValue(undefined as any);
+  });
+
+  it('starts with showTransition=false', () => {
+    const { result } = renderHook(() => useTurnTransition(baseInput));
+    expect(result.current.showTransition).toBe(false);
+    expect(result.current.transitionPlayerName).toBe('');
+    expect(result.current.isTransitionForCurrentUser).toBe(false);
+  });
+
+  it('handleTransitionComplete sets showTransition to false', async () => {
+    // Set up multi-device transition to get showTransition=true
+    const msg1 = makeMessage('msg1');
+    vi.mocked(latestMessageByType).mockReturnValue(msg1);
+    vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(false)); // initially not self
+
+    const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+      initialProps: { ...baseInput },
+    });
+
+    // New message + now self
+    const msg2 = makeMessage('msg2');
+    vi.mocked(latestMessageByType).mockReturnValue(msg2);
+    vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(true));
+    rerender({ ...baseInput });
+    await act(async () => {});
+
+    expect(result.current.showTransition).toBe(true);
+
+    act(() => result.current.handleTransitionComplete());
+    expect(result.current.showTransition).toBe(false);
+  });
+
+  describe('local player path', () => {
+    const players = [makeLocalPlayer('Alice'), makeLocalPlayer('Bob')];
+    const session: LocalSessionSettings = {
+      showTurnTransitions: true,
+      enableTurnSounds: false,
+      showPlayerAvatars: false,
+    };
+    const localInput = {
+      ...baseInput,
+      isLocalPlayerRoom: true,
+      localPlayers: players,
+      sessionSettings: session,
+      currentPlayerIndex: 0,
+    };
+
+    it('no transition on first render (previousIndex === currentIndex)', () => {
+      const { result } = renderHook(() => useTurnTransition(localInput));
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('shows transition when turn changes with showTurnTransitions=true and playerDialog=false', async () => {
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...localInput, currentPlayerIndex: 0 },
+      });
+      rerender({ ...localInput, currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(true);
+      expect(result.current.transitionPlayerName).toBe('Bob');
+      expect(result.current.isTransitionForCurrentUser).toBe(false);
+    });
+
+    it('does not show transition when playerDialog=true', async () => {
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...localInput, currentPlayerIndex: 0, playerDialog: true },
+      });
+      rerender({ ...localInput, currentPlayerIndex: 1, playerDialog: true });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('does not show transition when showTurnTransitions=false', async () => {
+      const input = {
+        ...localInput,
+        sessionSettings: { ...session, showTurnTransitions: false },
+      };
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...input, currentPlayerIndex: 0 },
+      });
+      rerender({ ...input, currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('does not trigger when isLocalPlayerRoom=false', async () => {
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...localInput, isLocalPlayerRoom: false, currentPlayerIndex: 0 },
+      });
+      rerender({ ...localInput, isLocalPlayerRoom: false, currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('does not trigger when localPlayers is empty', async () => {
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...localInput, localPlayers: [], currentPlayerIndex: 0 },
+      });
+      rerender({ ...localInput, localPlayers: [], currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('plays sound on turn change when enableTurnSounds=true and player has sound', async () => {
+      const mockSound = { id: 'chime', src: 'chime.mp3' } as any;
+      vi.mocked(getSoundById).mockReturnValue(mockSound);
+
+      const input = {
+        ...localInput,
+        localPlayers: [makeLocalPlayer('Alice'), makeLocalPlayer('Bob', 'chime')],
+        sessionSettings: { ...session, enableTurnSounds: true },
+      };
+      const { rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...input, currentPlayerIndex: 0 },
+      });
+      rerender({ ...input, currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(getSoundById).toHaveBeenCalledWith('chime');
+      expect(playSound).toHaveBeenCalledWith(mockSound);
+    });
+
+    it('does not call playSound when player has no sound even if enableTurnSounds=true', async () => {
+      const input = {
+        ...localInput,
+        localPlayers: [makeLocalPlayer('Alice'), makeLocalPlayer('Bob')], // no sound
+        sessionSettings: { ...session, enableTurnSounds: true },
+      };
+      const { rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...input, currentPlayerIndex: 0 },
+      });
+      rerender({ ...input, currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(playSound).not.toHaveBeenCalled();
+    });
+
+    it('does not call playSound when getSoundById returns null', async () => {
+      vi.mocked(getSoundById).mockReturnValue(null);
+      const input = {
+        ...localInput,
+        localPlayers: [makeLocalPlayer('Alice'), makeLocalPlayer('Bob', 'chime')],
+        sessionSettings: { ...session, enableTurnSounds: true },
+      };
+      const { rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...input, currentPlayerIndex: 0 },
+      });
+      rerender({ ...input, currentPlayerIndex: 1 });
+      await act(async () => {});
+
+      expect(playSound).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('multi-device path', () => {
+    it('shows transition: new msg + nextPlayer.isSelf + prev not self + !othersDialog', async () => {
+      const msg1 = makeMessage('msg1');
+      vi.mocked(latestMessageByType).mockReturnValue(msg1);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(false)); // initially not self
+
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...baseInput },
+      });
+
+      // New message + now it's our turn
+      const msg2 = makeMessage('msg2');
+      vi.mocked(latestMessageByType).mockReturnValue(msg2);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(true, 'Alice'));
+      rerender({ ...baseInput });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(true);
+      expect(result.current.isTransitionForCurrentUser).toBe(true);
+      expect(result.current.transitionPlayerName).toBe('Alice');
+    });
+
+    it('does not show transition when othersDialog=true', async () => {
+      const msg1 = makeMessage('msg1');
+      vi.mocked(latestMessageByType).mockReturnValue(msg1);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(false));
+
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...baseInput, othersDialog: true },
+      });
+
+      const msg2 = makeMessage('msg2');
+      vi.mocked(latestMessageByType).mockReturnValue(msg2);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(true));
+      rerender({ ...baseInput, othersDialog: true });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('does not show transition when isLocalPlayerRoom=true', async () => {
+      const msg1 = makeMessage('msg1');
+      vi.mocked(latestMessageByType).mockReturnValue(msg1);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(false));
+
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...baseInput, isLocalPlayerRoom: true },
+      });
+
+      const msg2 = makeMessage('msg2');
+      vi.mocked(latestMessageByType).mockReturnValue(msg2);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(true));
+      rerender({ ...baseInput, isLocalPlayerRoom: true });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('does not show transition when nextPlayer.isSelf stays false', async () => {
+      const msg1 = makeMessage('msg1');
+      vi.mocked(latestMessageByType).mockReturnValue(msg1);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(false));
+
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...baseInput },
+      });
+
+      const msg2 = makeMessage('msg2');
+      vi.mocked(latestMessageByType).mockReturnValue(msg2);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(false)); // still not self
+      rerender({ ...baseInput });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+
+    it('does not show transition when previous was already self (no change)', async () => {
+      const msg1 = makeMessage('msg1');
+      vi.mocked(latestMessageByType).mockReturnValue(msg1);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(true)); // already self at start
+
+      const { result, rerender } = renderHook((p) => useTurnTransition(p), {
+        initialProps: { ...baseInput },
+      });
+
+      const msg2 = makeMessage('msg2');
+      vi.mocked(latestMessageByType).mockReturnValue(msg2);
+      vi.mocked(useTurnIndicator).mockReturnValue(makeNextPlayer(true)); // still self
+      rerender({ ...baseInput });
+      await act(async () => {});
+
+      expect(result.current.showTransition).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useAuthSync.ts
+++ b/src/hooks/useAuthSync.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { User } from '@/types';
+
+export interface SyncStatus {
+  syncing: boolean;
+  lastSync: Date | null;
+}
+
+export function useAuthSync(user: User | null) {
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>({ syncing: false, lastSync: null });
+  const syncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const deferTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const performSync = useCallback(
+    async (syncFn: () => Promise<boolean>): Promise<boolean> => {
+      if (syncTimeoutRef.current) {
+        clearTimeout(syncTimeoutRef.current);
+        syncTimeoutRef.current = null;
+      }
+      if (!user || user.isAnonymous) return false;
+
+      try {
+        setSyncStatus((prev) => ({ syncing: true, lastSync: prev.lastSync }));
+        await syncFn();
+        setSyncStatus({ syncing: false, lastSync: new Date() });
+        return true;
+      } catch {
+        setSyncStatus((prev) => ({ syncing: false, lastSync: prev.lastSync }));
+        return false;
+      }
+    },
+    [user]
+  );
+
+  const syncData = useCallback(async (): Promise<boolean> => {
+    const { syncAllDataToFirebase } = await import('@/services/syncService');
+    return performSync(syncAllDataToFirebase);
+  }, [performSync]);
+
+  const intelligentSync = useCallback(async (): Promise<{
+    success: boolean;
+    conflicts?: string[];
+  }> => {
+    if (!user || user.isAnonymous) {
+      return { success: false, conflicts: ['User not logged in or is anonymous'] };
+    }
+    try {
+      setSyncStatus((prev) => ({ syncing: true, lastSync: prev.lastSync }));
+      const { intelligentSync: runIntelligentSync } = await import('@/services/syncService');
+      const result = await runIntelligentSync();
+      setSyncStatus({ syncing: false, lastSync: new Date() });
+      return result;
+    } catch {
+      setSyncStatus((prev) => ({ syncing: false, lastSync: prev.lastSync }));
+      return { success: false, conflicts: ['Sync failed due to error'] };
+    }
+  }, [user]);
+
+  // Start or stop sync lifecycle when user changes
+  useEffect(() => {
+    if (!user || user.isAnonymous) {
+      import('@/services/syncService')
+        .then(({ stopPeriodicSync }) => stopPeriodicSync())
+        .catch(() => undefined);
+      return;
+    }
+
+    const deferSync = () => {
+      if (syncTimeoutRef.current) clearTimeout(syncTimeoutRef.current);
+
+      syncTimeoutRef.current = setTimeout(async () => {
+        setSyncStatus({ syncing: true, lastSync: null });
+        try {
+          const { syncDataFromFirebase, startPeriodicSync } =
+            await import('@/services/syncService');
+          await syncDataFromFirebase();
+          setSyncStatus({ syncing: false, lastSync: new Date() });
+          startPeriodicSync();
+        } catch {
+          setSyncStatus({ syncing: false, lastSync: null });
+        } finally {
+          syncTimeoutRef.current = null;
+        }
+      }, 3000);
+    };
+
+    if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(deferSync, { timeout: 10000 });
+    } else {
+      deferTimeoutRef.current = setTimeout(deferSync, 5000);
+    }
+
+    return () => {
+      if (syncTimeoutRef.current) {
+        clearTimeout(syncTimeoutRef.current);
+        syncTimeoutRef.current = null;
+      }
+      if (deferTimeoutRef.current) {
+        clearTimeout(deferTimeoutRef.current);
+        deferTimeoutRef.current = null;
+      }
+    };
+  }, [user]);
+
+  return { syncStatus, syncData, intelligentSync };
+}

--- a/src/hooks/useGameSettingsWiring.ts
+++ b/src/hooks/useGameSettingsWiring.ts
@@ -1,0 +1,61 @@
+import { Params, useParams } from 'react-router-dom';
+import { getActiveBoard, upsertBoard } from '@/stores/gameBoard';
+import { handleUser, sendRoomSettingsMessage } from '@/services/roomSettingsService';
+
+import type { SubmitContext, SubmitDependencies } from '@/services/gameSettingsOrchestrator';
+import { getActiveTiles } from '@/stores/customTiles';
+import sendGameSettingsMessage from '@/services/gameSettingsMessage';
+import useAuth from '@/context/hooks/useAuth';
+import useGameBoard from './useGameBoard';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { useLocalPlayers } from './useLocalPlayers';
+import useMessages from '@/context/hooks/useMessages';
+import useRoomNavigate from './useRoomNavigate';
+import { useSettings } from '@/stores/settingsStore';
+import { useTranslation } from 'react-i18next';
+import { recordGameStart } from '@/services/playerStatsService';
+import { getContentGameMode } from '@/helpers/strings';
+
+export interface GameSettingsWiring {
+  ctx: SubmitContext;
+  deps: SubmitDependencies;
+}
+
+export function useGameSettingsWiring(): GameSettingsWiring {
+  const { user, updateUser } = useAuth();
+  const { id: currentRoom } = useParams<Params>();
+  const { t } = useTranslation();
+  const updateGameBoardTiles = useGameBoard();
+  const [settings, updateSettings] = useSettings();
+  const customTiles = useLiveQuery(() => getActiveTiles(getContentGameMode(settings?.gameMode)));
+  const gameBoard = useLiveQuery(getActiveBoard);
+  const navigate = useRoomNavigate();
+  const { messages } = useMessages();
+  const { createLocalSession, hasLocalPlayers } = useLocalPlayers();
+
+  const ctx: SubmitContext = {
+    user,
+    currentRoom,
+    currentRoomTileCount: settings?.roomTileCount,
+    messages,
+    gameBoard,
+    customTiles,
+    hasLocalPlayers,
+    settingsSnapshot: settings,
+  };
+
+  const deps: SubmitDependencies = {
+    updateUser: (displayName: string) => handleUser(user, displayName, updateUser),
+    updateGameBoardTiles,
+    sendRoomSettingsFn: sendRoomSettingsMessage,
+    upsertBoardFn: upsertBoard,
+    sendGameSettingsFn: sendGameSettingsMessage,
+    createLocalSessionFn: createLocalSession,
+    updateSettingsFn: updateSettings,
+    navigateFn: navigate,
+    translateFn: t,
+    recordGameStartFn: recordGameStart,
+  };
+
+  return { ctx, deps };
+}

--- a/src/hooks/usePrivateRoomMonitor.ts
+++ b/src/hooks/usePrivateRoomMonitor.ts
@@ -1,4 +1,4 @@
-import latestMessageByType from '@/helpers/messages';
+import { latestMessageByType } from '@/helpers/messages';
 import useAuth from '@/context/hooks/useAuth';
 import useGameBoard from '@/hooks/useGameBoard';
 import { useSettings } from '@/stores/settingsStore';

--- a/src/hooks/useSendSettings.ts
+++ b/src/hooks/useSendSettings.ts
@@ -4,7 +4,7 @@ import sendGameSettingsMessage from '@/services/gameSettingsMessage';
 import { useSettings } from '@/stores/settingsStore';
 import { useTranslation } from 'react-i18next';
 import { importActions } from '@/services/dexieActionImport';
-import latestMessageByType, { latestMessageBy } from '@/helpers/messages';
+import { latestMessageByType, latestMessageBy } from '@/helpers/messages';
 import { Params, useParams } from 'react-router-dom';
 import { getActiveTiles } from '@/stores/customTiles';
 import { useLiveQuery } from 'dexie-react-hooks';

--- a/src/hooks/useSettingsToFormData.ts
+++ b/src/hooks/useSettingsToFormData.ts
@@ -1,5 +1,5 @@
 import useMessages from '@/context/hooks/useMessages';
-import latestMessageByType from '@/helpers/messages';
+import { latestMessageByType } from '@/helpers/messages';
 import { useEffect, useState, Dispatch, SetStateAction, useRef } from 'react';
 import { useSettings } from '@/stores/settingsStore';
 import { RoomMessage } from '@/types/Message';

--- a/src/hooks/useSubmitGameSettings.ts
+++ b/src/hooks/useSubmitGameSettings.ts
@@ -1,26 +1,8 @@
-import { Params, useParams } from 'react-router-dom';
-import { getActiveBoard, upsertBoard } from '@/stores/gameBoard';
-import {
-  SubmitContext,
-  SubmitDependencies,
-  submitGameSettings,
-} from '@/services/gameSettingsOrchestrator';
-import { handleUser, sendRoomSettingsMessage } from '@/services/roomSettingsService';
+import { SubmitDependencies, submitGameSettings } from '@/services/gameSettingsOrchestrator';
 
-import { Settings } from '@/types/Settings';
-import { getActiveTiles } from '@/stores/customTiles';
-import sendGameSettingsMessage from '@/services/gameSettingsMessage';
-import useAuth from '@/context/hooks/useAuth';
+import type { Settings } from '@/types/Settings';
 import { useCallback, useState } from 'react';
-import useGameBoard from './useGameBoard';
-import { useLiveQuery } from 'dexie-react-hooks';
-import { useLocalPlayers } from './useLocalPlayers';
-import useMessages from '@/context/hooks/useMessages';
-import useRoomNavigate from './useRoomNavigate';
-import { useSettings } from '@/stores/settingsStore';
-import { useTranslation } from 'react-i18next';
-import { recordGameStart } from '@/services/playerStatsService';
-import { getContentGameMode } from '@/helpers/strings';
+import { useGameSettingsWiring } from './useGameSettingsWiring';
 
 export interface GameSettingsSubmitResult {
   submit: (formData: Settings, actionsList: any) => Promise<void>;
@@ -31,16 +13,7 @@ export interface GameSettingsSubmitResult {
 export default function useSubmitGameSettings(
   overrideDeps?: Partial<SubmitDependencies>
 ): GameSettingsSubmitResult {
-  const { user, updateUser } = useAuth();
-  const { id: currentRoom } = useParams<Params>();
-  const { t } = useTranslation();
-  const updateGameBoardTiles = useGameBoard();
-  const [settings, updateSettings] = useSettings();
-  const customTiles = useLiveQuery(() => getActiveTiles(getContentGameMode(settings?.gameMode)));
-  const gameBoard = useLiveQuery(getActiveBoard);
-  const navigate = useRoomNavigate();
-  const { messages } = useMessages();
-  const { createLocalSession, hasLocalPlayers } = useLocalPlayers();
+  const { ctx, deps } = useGameSettingsWiring();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -49,33 +22,8 @@ export default function useSubmitGameSettings(
       setIsSubmitting(true);
       setError(null);
 
-      const ctx: SubmitContext = {
-        user,
-        currentRoom,
-        currentRoomTileCount: settings?.roomTileCount,
-        messages,
-        gameBoard,
-        customTiles,
-        hasLocalPlayers,
-        settingsSnapshot: settings,
-      };
-
-      const deps: SubmitDependencies = {
-        updateUser: (displayName: string) => handleUser(user, displayName, updateUser),
-        updateGameBoardTiles,
-        sendRoomSettingsFn: sendRoomSettingsMessage,
-        upsertBoardFn: upsertBoard,
-        sendGameSettingsFn: sendGameSettingsMessage,
-        createLocalSessionFn: createLocalSession,
-        updateSettingsFn: updateSettings,
-        navigateFn: navigate,
-        translateFn: t,
-        recordGameStartFn: recordGameStart,
-        ...overrideDeps,
-      };
-
       try {
-        await submitGameSettings(formData, actionsList, ctx, deps);
+        await submitGameSettings(formData, actionsList, ctx, { ...deps, ...overrideDeps });
       } catch (err) {
         const e = err instanceof Error ? err : new Error('Submission failed');
         setError(e);
@@ -84,22 +32,7 @@ export default function useSubmitGameSettings(
         setIsSubmitting(false);
       }
     },
-    [
-      user,
-      updateUser,
-      currentRoom,
-      settings,
-      messages,
-      gameBoard,
-      customTiles,
-      hasLocalPlayers,
-      updateGameBoardTiles,
-      updateSettings,
-      navigate,
-      createLocalSession,
-      t,
-      overrideDeps,
-    ]
+    [ctx, deps, overrideDeps]
   );
 
   return { submit, isSubmitting, error };

--- a/src/hooks/useTurnTransition.ts
+++ b/src/hooks/useTurnTransition.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getSoundById, playSound } from '@/utils/gameSounds';
+
+import type { LocalPlayer, LocalSessionSettings } from '@/types';
+import latestMessageByType from '@/helpers/messages';
+import useMessages from '@/context/hooks/useMessages';
+import useTurnIndicator from '@/hooks/useTurnIndicator';
+
+export interface TurnTransitionInput {
+  localPlayers: LocalPlayer[];
+  sessionSettings: LocalSessionSettings | null | undefined;
+  currentPlayerIndex: number | null | undefined;
+  isLocalPlayerRoom: boolean;
+  playerDialog?: boolean;
+  othersDialog?: boolean;
+}
+
+export interface TurnTransitionResult {
+  showTransition: boolean;
+  transitionPlayerName: string;
+  isTransitionForCurrentUser: boolean;
+  handleTransitionComplete: () => void;
+}
+
+export function useTurnTransition({
+  localPlayers,
+  sessionSettings,
+  currentPlayerIndex,
+  isLocalPlayerRoom,
+  playerDialog,
+  othersDialog,
+}: TurnTransitionInput): TurnTransitionResult {
+  const [showTransition, setShowTransition] = useState(false);
+  const [transitionPlayerName, setTransitionPlayerName] = useState('');
+  const [isTransitionForCurrentUser, setIsTransitionForCurrentUser] = useState(false);
+
+  const previousPlayerIndexRef = useRef(currentPlayerIndex);
+
+  // Turn change detection for local players (only in pure local multiplayer mode)
+  useEffect(() => {
+    if (!localPlayers.length || !sessionSettings || !isLocalPlayerRoom) return;
+
+    const currentIndex = currentPlayerIndex ?? 0;
+    const previousIndex = previousPlayerIndexRef.current;
+
+    if (currentIndex !== previousIndex && previousIndex !== undefined) {
+      const newCurrentPlayer = localPlayers[currentIndex];
+
+      if (newCurrentPlayer) {
+        if (sessionSettings.showTurnTransitions && !playerDialog) {
+          setTransitionPlayerName(newCurrentPlayer.name);
+          setIsTransitionForCurrentUser(false);
+          setShowTransition(true);
+        }
+
+        if (sessionSettings.enableTurnSounds && newCurrentPlayer.sound) {
+          const sound = getSoundById(newCurrentPlayer.sound);
+          if (sound) {
+            playSound(sound).catch((error) => {
+              console.warn('Failed to play turn sound:', error);
+            });
+          }
+        }
+      }
+    }
+
+    previousPlayerIndexRef.current = currentIndex;
+  }, [currentPlayerIndex, localPlayers, sessionSettings, isLocalPlayerRoom, playerDialog]);
+
+  // Multi-device turn transitions (only when others' dialog is disabled)
+  const { messages } = useMessages();
+  const latestActionMessage = latestMessageByType(messages, 'actions');
+  const nextPlayer = useTurnIndicator(latestActionMessage);
+  const previousMessageRef = useRef(latestActionMessage);
+  const previousNextPlayerRef = useRef(nextPlayer);
+
+  useEffect(() => {
+    if (isLocalPlayerRoom || !nextPlayer || !latestActionMessage) return;
+
+    if (othersDialog) return;
+
+    const isNewMessage = latestActionMessage !== previousMessageRef.current;
+
+    if (isNewMessage && nextPlayer.isSelf && !previousNextPlayerRef.current?.isSelf) {
+      setTransitionPlayerName(nextPlayer.displayName);
+      setIsTransitionForCurrentUser(true);
+      setShowTransition(true);
+    }
+
+    previousMessageRef.current = latestActionMessage;
+    previousNextPlayerRef.current = nextPlayer;
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- stabilized: nextPlayer object ref changes each render; pin individual values instead
+  }, [
+    latestActionMessage,
+    nextPlayer?.uid,
+    nextPlayer?.isSelf,
+    nextPlayer?.displayName,
+    isLocalPlayerRoom,
+    othersDialog,
+  ]);
+
+  const handleTransitionComplete = useCallback(() => {
+    setShowTransition(false);
+  }, []);
+
+  return {
+    showTransition,
+    transitionPlayerName,
+    isTransitionForCurrentUser,
+    handleTransitionComplete,
+  };
+}

--- a/src/hooks/useTurnTransition.ts
+++ b/src/hooks/useTurnTransition.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { getSoundById, playSound } from '@/utils/gameSounds';
 
 import type { LocalPlayer, LocalSessionSettings } from '@/types';
-import latestMessageByType from '@/helpers/messages';
+import { latestMessageByType } from '@/helpers/messages';
 import useMessages from '@/context/hooks/useMessages';
 import useTurnIndicator from '@/hooks/useTurnIndicator';
 

--- a/src/stores/customGroups.ts
+++ b/src/stores/customGroups.ts
@@ -12,6 +12,7 @@ import i18next from 'i18next';
 import { nanoid } from 'nanoid';
 import { retryOnCursorError } from '@/utils/dbRecovery';
 import { analyticsTracking } from '@/services/analyticsTracking';
+import { waitForMigration } from '@/utils/migrationGuard';
 
 const { customGroups } = db;
 
@@ -419,23 +420,7 @@ export const getAllAvailableGroups = async (
   gameMode = 'online'
 ): Promise<CustomGroupPull[]> => {
   try {
-    // Check if migration is in progress and wait if necessary
-    const migrationInProgress = localStorage.getItem('blitzed-out-migration-in-progress');
-    if (migrationInProgress) {
-      const migrationData = JSON.parse(migrationInProgress);
-      const migrationAge = Date.now() - new Date(migrationData.startedAt).getTime();
-
-      // If migration is recent (less than 30 seconds), wait for it to complete
-      if (migrationAge < 30000) {
-        let waitCount = 0;
-        const maxWait = 60; // Maximum 3 seconds wait (60 * 50ms)
-
-        while (localStorage.getItem('blitzed-out-migration-in-progress') && waitCount < maxWait) {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          waitCount++;
-        }
-      }
-    }
+    await waitForMigration();
 
     // Ensure database is ready before any operations (skip in test environment)
     if (typeof db.isOpen === 'function' && !db.isOpen()) {

--- a/src/stores/customTiles.ts
+++ b/src/stores/customTiles.ts
@@ -5,7 +5,7 @@ import { CustomTile, CustomTilePull } from '@/types/customTiles';
 import { CustomTileFilters, PaginatedResult } from '@/types/dexieTypes';
 import { Collection, Table } from 'dexie';
 import { retryOnCursorError } from '@/utils/dbRecovery';
-import { MIGRATION_IN_PROGRESS_KEY, MIGRATION_TIMEOUT } from '@/services/migration/constants';
+import { waitForMigration } from '@/utils/migrationGuard';
 
 const { customTiles } = db;
 
@@ -82,29 +82,7 @@ export const getTiles = async (
   filters: Omit<CustomTileFilters, 'page' | 'limit' | 'paginated'> = {}
 ): Promise<CustomTilePull[]> => {
   try {
-    // Check if migration is in progress and wait if necessary
-    if (typeof window !== 'undefined') {
-      const migrationInProgress = localStorage.getItem(MIGRATION_IN_PROGRESS_KEY);
-      if (migrationInProgress) {
-        try {
-          const migrationData = JSON.parse(migrationInProgress);
-          const migrationAge = Date.now() - new Date(migrationData.startedAt).getTime();
-
-          // If migration is recent (less than timeout), wait for it to complete
-          if (migrationAge < MIGRATION_TIMEOUT) {
-            let waitCount = 0;
-            const maxWait = Math.ceil(MIGRATION_TIMEOUT / 50); // Maximum wait based on timeout (600 iterations for 30s)
-
-            while (localStorage.getItem(MIGRATION_IN_PROGRESS_KEY) && waitCount < maxWait) {
-              await new Promise((resolve) => setTimeout(resolve, 50));
-              waitCount++;
-            }
-          }
-        } catch {
-          // Ignore JSON parse errors and continue
-        }
-      }
-    }
+    await waitForMigration();
 
     return await retryOnCursorError(
       db,

--- a/src/stores/messagesStore.ts
+++ b/src/stores/messagesStore.ts
@@ -1,10 +1,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { Message, MessageType } from '@/types/Message';
-import latestMessageByType, {
+import {
+  filterMessages,
+  filterMessagesByType,
+  latestMessage,
+  latestMessageByType,
   normalSortedMessages,
   orderedMessagesByType,
-  latestMessage,
 } from '@/helpers/messages';
 import { parseMessageTimestamp } from '@/helpers/timestamp';
 
@@ -137,14 +140,7 @@ export const useMessagesStore = create<MessagesStore>()(
       // Selectors - Optimized for performance
       getMessagesByType: (type) => {
         const { messages } = get();
-        // Use a more efficient filter approach for large message arrays
-        const filtered: Message[] = [];
-        for (let i = 0; i < messages.length; i++) {
-          if (messages[i].type === type) {
-            filtered.push(messages[i]);
-          }
-        }
-        return filtered;
+        return filterMessagesByType(messages, type);
       },
 
       getLatestMessage: () => {
@@ -159,14 +155,7 @@ export const useMessagesStore = create<MessagesStore>()(
 
       getFilteredMessages: (predicate) => {
         const { messages } = get();
-        // Use for loop for better performance on large arrays
-        const filtered: Message[] = [];
-        for (let i = 0; i < messages.length; i++) {
-          if (predicate(messages[i])) {
-            filtered.push(messages[i]);
-          }
-        }
-        return filtered;
+        return filterMessages(messages, predicate);
       },
 
       getOrderedMessagesByType: (type, order = 'ASC') => {

--- a/src/utils/__tests__/migrationGuard.test.ts
+++ b/src/utils/__tests__/migrationGuard.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { waitForMigration } from '../migrationGuard';
+import { MIGRATION_IN_PROGRESS_KEY, MIGRATION_TIMEOUT } from '@/services/migration/constants';
+
+describe('waitForMigration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('returns immediately when no migration in progress', async () => {
+    const start = Date.now();
+    await waitForMigration();
+    expect(Date.now() - start).toBe(0);
+  });
+
+  it('returns immediately when migration started beyond MIGRATION_TIMEOUT ago', async () => {
+    const staleStart = new Date(Date.now() - MIGRATION_TIMEOUT - 1000).toISOString();
+    localStorage.setItem(MIGRATION_IN_PROGRESS_KEY, JSON.stringify({ startedAt: staleStart }));
+
+    await waitForMigration();
+    // Should resolve immediately — stale lock
+  });
+
+  it('waits and returns when migration completes during wait', async () => {
+    localStorage.setItem(
+      MIGRATION_IN_PROGRESS_KEY,
+      JSON.stringify({ startedAt: new Date().toISOString() })
+    );
+
+    const waitPromise = waitForMigration();
+
+    // Simulate migration completing after 3 ticks
+    await vi.advanceTimersByTimeAsync(150);
+    localStorage.removeItem(MIGRATION_IN_PROGRESS_KEY);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await waitPromise;
+    // No assertion needed — just ensure it resolved
+  });
+
+  it('returns after maxWait iterations even if migration never clears', async () => {
+    localStorage.setItem(
+      MIGRATION_IN_PROGRESS_KEY,
+      JSON.stringify({ startedAt: new Date().toISOString() })
+    );
+
+    const waitPromise = waitForMigration();
+
+    // Advance past the full timeout
+    await vi.advanceTimersByTimeAsync(MIGRATION_TIMEOUT + 1000);
+
+    await waitPromise;
+    // Resolved without hanging
+  });
+
+  it('ignores invalid JSON in localStorage and returns immediately', async () => {
+    localStorage.setItem(MIGRATION_IN_PROGRESS_KEY, 'not-valid-json');
+
+    await waitForMigration();
+    // Should not throw
+  });
+
+  it('returns immediately in non-browser environments', async () => {
+    const originalWindow = globalThis.window;
+    // @ts-expect-error simulate no window
+    delete globalThis.window;
+
+    await waitForMigration();
+
+    globalThis.window = originalWindow;
+  });
+});

--- a/src/utils/migrationGuard.ts
+++ b/src/utils/migrationGuard.ts
@@ -1,0 +1,25 @@
+import { MIGRATION_IN_PROGRESS_KEY, MIGRATION_TIMEOUT } from '@/services/migration/constants';
+
+export async function waitForMigration(): Promise<void> {
+  if (typeof window === 'undefined') return;
+
+  const raw = localStorage.getItem(MIGRATION_IN_PROGRESS_KEY);
+  if (!raw) return;
+
+  try {
+    const { startedAt } = JSON.parse(raw);
+    const age = Date.now() - new Date(startedAt).getTime();
+
+    if (age >= MIGRATION_TIMEOUT) return;
+
+    const maxWait = Math.ceil(MIGRATION_TIMEOUT / 50);
+    let count = 0;
+
+    while (localStorage.getItem(MIGRATION_IN_PROGRESS_KEY) && count < maxWait) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      count++;
+    }
+  } catch {
+    // Ignore malformed lock data
+  }
+}

--- a/src/views/Cast/index.tsx
+++ b/src/views/Cast/index.tsx
@@ -10,7 +10,7 @@ import RoomBackground from '@/components/RoomBackground';
 import ToastAlert from '@/components/ToastAlert';
 import { Trans } from 'react-i18next';
 import { getAuth } from 'firebase/auth';
-import latestMessageByType from '@/helpers/messages';
+import { latestMessageByType } from '@/helpers/messages';
 import { loginAnonymously } from '@/services/firebase';
 import { t } from 'i18next';
 import useFullscreenStatus from '@/hooks/useFullscreenStatus';

--- a/src/views/Room/index.tsx
+++ b/src/views/Room/index.tsx
@@ -2,7 +2,6 @@ import './styles.css';
 
 import { Box, CircularProgress } from '@mui/material';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { getSoundById, playSound } from '@/utils/gameSounds';
 import { getGameSessionAnalytics, isRoomReady } from './roomHelpers';
 
 import GameSettingsDialog from '@/components/GameSettingsDialog';
@@ -30,9 +29,7 @@ import { useSettings } from '@/stores/settingsStore';
 import { useTranslation } from 'react-i18next';
 import useUrlImport from '@/hooks/useUrlImport';
 import useWakeLock from '@/hooks/useWakeLock';
-import useMessages from '@/context/hooks/useMessages';
-import useTurnIndicator from '@/hooks/useTurnIndicator';
-import latestMessageByType from '@/helpers/messages';
+import { useTurnTransition } from '@/hooks/useTurnTransition';
 import { analytics } from '@/services/analytics';
 
 import BottomTabs from './BottomTabs';
@@ -70,10 +67,6 @@ export default function Room() {
   // Local player integration for turn transitions and sounds
   const { localPlayers, sessionSettings, currentPlayerIndex, isLocalPlayerRoom } =
     useLocalPlayers();
-  const [showTransition, setShowTransition] = useState(false);
-  const [transitionPlayerName, setTransitionPlayerName] = useState('');
-  const [isTransitionForCurrentUser, setIsTransitionForCurrentUser] = useState(false);
-  const previousPlayerIndexRef = useRef(currentPlayerIndex);
 
   const gameBoard = useLiveQuery(getActiveBoard)?.tiles;
 
@@ -84,84 +77,19 @@ export default function Room() {
     actionCountRef.current += 1;
   }, []);
 
-  // Turn change detection for local players (only in pure local multiplayer mode)
-  useEffect(() => {
-    if (!localPlayers.length || !sessionSettings || !isLocalPlayerRoom) return;
-
-    const currentIndex = currentPlayerIndex ?? 0;
-    const previousIndex = previousPlayerIndexRef.current;
-
-    // Check if turn changed
-    if (currentIndex !== previousIndex && previousIndex !== undefined) {
-      const newCurrentPlayer = localPlayers[currentIndex];
-
-      if (newCurrentPlayer) {
-        // Show turn transition if enabled AND playerDialog is disabled
-        // (to avoid showing both roll dialog and turn transition)
-        if (sessionSettings.showTurnTransitions && !settings.playerDialog) {
-          setTransitionPlayerName(newCurrentPlayer.name);
-          setIsTransitionForCurrentUser(false); // Always show player name for local multiplayer
-          setShowTransition(true);
-        }
-
-        // Play turn sound if enabled and player has a sound
-        if (sessionSettings.enableTurnSounds && newCurrentPlayer.sound) {
-          const sound = getSoundById(newCurrentPlayer.sound);
-          if (sound) {
-            playSound(sound).catch((error) => {
-              console.warn('Failed to play turn sound:', error);
-            });
-          }
-        }
-      }
-    }
-
-    // Update refs
-    previousPlayerIndexRef.current = currentIndex;
-  }, [currentPlayerIndex, localPlayers, sessionSettings, isLocalPlayerRoom, settings.playerDialog]);
-
-  // Multi-device turn transitions (only when others' dialog is disabled)
-  const { messages } = useMessages();
-  const latestActionMessage = latestMessageByType(messages, 'actions');
-  const nextPlayer = useTurnIndicator(latestActionMessage);
-  const previousMessageRef = useRef(latestActionMessage);
-  const previousNextPlayerRef = useRef(nextPlayer);
-
-  useEffect(() => {
-    // Only show transitions for multi-device when NOT in local player room
-    // AND when "show others' dialog" is disabled (so users still get turn awareness)
-    if (isLocalPlayerRoom || !nextPlayer || !latestActionMessage) return;
-
-    const { othersDialog } = settings;
-    if (othersDialog) return; // Skip if others' dialog is enabled
-
-    // Check if this is a new message (different from previous)
-    const isNewMessage = latestActionMessage !== previousMessageRef.current;
-
-    // Only show transition if it's a new message AND nextPlayer changed to be yourself
-    // In multi-device mode, playerDialog only affects YOUR rolls, not the "Your Turn" transition
-    if (isNewMessage && nextPlayer.isSelf && !previousNextPlayerRef.current?.isSelf) {
-      // Show turn transition when it's your turn (multi-device)
-      setTransitionPlayerName(nextPlayer.displayName);
-      setIsTransitionForCurrentUser(true); // Show "Your Turn" for multi-device
-      setShowTransition(true);
-    }
-
-    // Update refs to track changes
-    previousMessageRef.current = latestActionMessage;
-    previousNextPlayerRef.current = nextPlayer;
-  }, [
-    latestActionMessage,
-    nextPlayer?.uid,
-    nextPlayer?.isSelf,
-    nextPlayer?.displayName,
+  const {
+    showTransition,
+    transitionPlayerName,
+    isTransitionForCurrentUser,
+    handleTransitionComplete,
+  } = useTurnTransition({
+    localPlayers,
+    sessionSettings,
+    currentPlayerIndex,
     isLocalPlayerRoom,
-    settings.othersDialog,
-  ]); // Stabilized dependencies with eslint-disable for performance
-
-  const handleTransitionComplete = useCallback(() => {
-    setShowTransition(false);
-  }, []);
+    playerDialog: settings.playerDialog,
+    othersDialog: settings.othersDialog,
+  });
 
   // Use usePlayerMove directly
   const { tile } = usePlayerMove(room, rollValue, gameBoard);


### PR DESCRIPTION
## Summary

- **AuthContext + sync** (`useAuthSync`): extracted auth sync lifecycle from AuthProvider into testable hook; reduced auth context from ~445 to ~200 lines
- **Game settings wiring** (`useGameSettingsWiring`): collapsed 8 hook + 4 service imports behind one seam in `useSubmitGameSettings`
- **Room view** (`useTurnTransition`): extracted turn transition logic (player detection, sound, dialog gating) into standalone hook with 16 tests
- **Migration guard** (`waitForMigration`): extracted shared migration polling loop from `customTiles` and `customGroups`; fixed live bug where `customGroups` hardcoded the key string and only waited 3s instead of 30s
- **Message helpers**: filled contract gap between `helpers/messages.ts` and `messagesStore`; fixed `normalSortedMessages` mutation bug and `sortedMessages` deep-copy; converted `latestMessageByType` to named export; removed manual for-loops from store

## Test plan

- [ ] All 1264 tests pass (`npm run test:failures`)
- [ ] TypeScript clean (`npm run type-check`)
- [ ] Auth flow: sign in, sign out, anonymous → named user upgrade
- [ ] Room: join, roll, turn transitions show for local player games
- [ ] Messages: chat sorts correctly, latest action/room message resolves
- [ ] Game settings: submit triggers board rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)