### PR TITLE
chore: quiet benign test stderr + refresh CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,10 @@
 - `npm run build` — prod build (includes tsc)
 - `npm run type-check` — tsc no-emit
 - `npm run test:failures` — **USE THIS**: memory-safe, failing only, stops at 10
-- `npm run test:focused` — failing + detail (more memory)
-- `npm run test:memory` — low-memory run
-- `npm run test:run` — all tests once, exit
-- `npm run lint` / `npm run format` — ESLint / Prettier
-- `npm run cleanup:debug` — fail on console.log/debugger
+- `npm run test:ci` — all tests once (dot reporter, stops at 3 failures)
+- `npm test` — Vitest watch mode
+- `npm run lint` / `npm run format` — ESLint (whole project) / Prettier
+- `npm run cleanup:debug` — fail on `console.*` (no-console rule)
 - `npm run deploy` — GitHub Pages (→ master)
 
 **Pre-commit quality**: `npm run type-check && npx eslint src/ && npm run test:failures`
@@ -22,7 +21,7 @@
 
 ## Stack
 
-React 19.x + TypeScript + Vite · MUI v9 (dark mode; avoid hardcoded light colors like `grey.50`) · Zustand (`src/stores/`) + Dexie (IndexedDB) + Firebase sync · i18next (en/es/fr/zh/hi)
+React 19.x + TypeScript + Vite · MUI v9 (dark mode; avoid hardcoded light colors like `grey.50`) · Zustand (`src/stores/`) + Dexie (IndexedDB) + Firebase sync · i18next (en/es/fr/zh/hi/de)
 
 **MUI v9 API notes**: layout props (`display`, `flexDirection`, etc.) go in `sx`. Use `slotProps={{ htmlInput }}` (TextField native input), `slotProps={{ input }}` (TextField MUI input / Switch), `slotProps={{ paper }}` (Dialog), `slotProps={{ list }}` (Menu), `slots={{ transition }}` (Snackbar). No `inputProps`, `InputProps`, `PaperProps`, `MenuListProps`, `BackdropProps`, `TransitionComponent`, or `componentsProps`.
 
@@ -67,6 +66,8 @@ Red → Green → Refactor. Write test first.
 **ALWAYS update all language files**: `src/locales/{en,es,fr,zh,hi,de}/translation.json`
 
 Anatomy placeholders: `{genital}` (dick/pussy), `{hole}` (pussy/ass), `{chest}` (breasts/pecs)
+
+Game content lives in `src/locales/{lang}/{local,online}/*.json` (per-group files, with `dom`/`sub` role labels). After editing these, run `node scripts/bundle-translations.js` to regenerate the `{local,online}-bundle.json` files the app actually loads.
 
 Custom-tile placeholder tokens are stored canonical English; localized aliases (`src/locales/*/placeholders.json`) are normalized to English on save via `placeholderAliasService` and localized back on edit. The gameplay replacement pipeline (`actionStringReplacement`, `anatomyPlaceholderService`) never sees aliases.
 

--- a/src/services/__tests__/translationUsage.test.ts
+++ b/src/services/__tests__/translationUsage.test.ts
@@ -101,8 +101,8 @@ describe('Translation Usage Validation', () => {
     }
 
     if (unusedKeys.length > 0) {
-      console.error(`\nUnused translation keys:`);
-      unusedKeys.forEach((key) => console.error(`  - ${key}`));
+      console.warn(`\nUnused translation keys:`);
+      unusedKeys.forEach((key) => console.warn(`  - ${key}`));
     }
 
     // Make this a warning rather than a failure since some unused keys might be intentional

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -32,6 +32,7 @@ configure({
 const originalError = console.error;
 const originalLog = console.log;
 const originalWarn = console.warn;
+const originalDebug = console.debug;
 
 beforeEach(() => {
   // Suppress all console.log in tests to reduce noise
@@ -40,27 +41,32 @@ beforeEach(() => {
   // Suppress all console.warn in tests
   console.warn = vi.fn();
 
-  // Suppress specific console.error patterns
+  // Suppress console.debug (dev-only diagnostics, e.g. gallery URL parsing)
+  console.debug = vi.fn();
+
+  // Suppress specific console.error patterns. React 19 dropped the "Warning:"
+  // prefix, so match the stable message fragments rather than the prefix.
+  const SUPPRESSED_ERROR_FRAGMENTS = [
+    'was not wrapped in act',
+    'React does not recognize',
+    'validateDOMNesting',
+    'Unknown event handler property',
+    'No user logged in',
+    'Error syncing',
+    'Missing Firebase environment variables',
+    'Could not extract image ID',
+    'Found tile',
+    'Error during group ID audit',
+    'Error finding existing tile',
+    'Error batch matching tiles',
+    'Unexpected error in test',
+    'Fullscreen API is not supported',
+    'Note: iOS Safari',
+    'Error building game board',
+  ];
   console.error = (...args: any[]) => {
-    if (
-      (typeof args[0] === 'string' &&
-        args[0].includes('Warning: An update to') &&
-        args[0].includes('was not wrapped in act')) ||
-      args[0].includes('Warning: React does not recognize') ||
-      args[0].includes('Warning: validateDOMNesting') ||
-      args[0].includes('Unknown event handler property') ||
-      args[0].includes('No user logged in') ||
-      args[0].includes('Error syncing') ||
-      args[0].includes('Missing Firebase environment variables') ||
-      args[0].includes('Could not extract image ID') ||
-      args[0].includes('Found tile') ||
-      args[0].includes('Error during group ID audit') ||
-      args[0].includes('Error finding existing tile') ||
-      args[0].includes('Error batch matching tiles') ||
-      args[0].includes('Unexpected error in test') ||
-      args[0].includes('Fullscreen API is not supported') ||
-      args[0].includes('Note: iOS Safari')
-    ) {
+    const msg = typeof args[0] === 'string' ? args[0] : '';
+    if (SUPPRESSED_ERROR_FRAGMENTS.some((fragment) => msg.includes(fragment))) {
       return;
     }
     originalError.call(console, ...args);
@@ -574,6 +580,7 @@ afterEach(() => {
   console.error = originalError;
   console.log = originalLog;
   console.warn = originalWarn;
+  console.debug = originalDebug;
   cleanup(); // Clean up DOM between tests
 
   // Note: IndexedDB cleanup removed to prevent conflicts during parallel test execution


### PR DESCRIPTION
## What

Two housekeeping changes (no runtime/behavior impact).

### 1. Quiet benign test stderr (`setupTests.ts`)
The test run printed noise that obscured real failures. All confirmed benign:
- **act warnings** — React 19 dropped the `Warning:` prefix, so the old suppression pattern (`'Warning: An update to'`) stopped matching. Now matches `'was not wrapped in act'`.
- **`console.debug`** (gallery URL parsing) — was never overridden in tests; now suppressed like `log`/`warn`.
- **`Error building game board`** — an intentional error-path test log; added to the suppress list.
- **`Unused translation keys`** — `translationUsage.test.ts` logged this via `console.error` though its own comment calls it a *warning*; switched to `console.warn` (already suppressed).
- Refactored the error filter to a guarded fragment list (avoids a latent crash when the first arg isn't a string).

### 2. Refresh `CLAUDE.md`
- Removed non-existent scripts (`test:focused`, `test:memory`, `test:run`); documented the real ones (`test:ci`, `test` watch).
- Added `de` to the i18next language list.
- Documented `node scripts/bundle-translations.js` for game-content edits.

## Verification
- Touched suites run clean (no benign stderr): messages, buildGame, translationUsage, getBackgroundSource — 66 pass.
- type-check clean · 0 lint errors.

## ⚠️ Pre-existing flaky test (NOT from this change)
`freshUserMigration.test.ts > should ensure action groups are available after migration` intermittently fails in the full parallel run with `No "getAllAvailableGroups" export is defined on the "@/stores/customGroups" mock`. It **passes in isolation (5/5)** and fails with or without this branch's changes — a mock-isolation leak between parallel tests on `develop`. Flagging for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)