### PR TITLE
refactor(cast): extract pure cast helpers + TDD; document cast terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,3 +99,29 @@ as presence are separate from Firestore persistence and must degrade gracefully 
 Network lost mid-session. Firestore `persistentLocalCache` queues Firestore writes locally and
 syncs on reconnect. Realtime Database features such as presence may be unavailable until network
 returns.
+
+---
+
+## Casting & TV
+
+How a Room's game state is mirrored onto a television. Three distinct pieces, often loosely
+called "the receiver" — they are not the same thing.
+
+### Cast Sender
+
+The control surface in the player's own browser that owns the cast session and tells the TV what
+to show. Today this is Chromecast-specific. A Sender starts/stops a session and pushes the target
+Room to the receiving display. It does not render the game itself.
+
+### Receiver shell
+
+The thin HTML application registered to a casting platform under a vendor-issued application ID,
+hosted outside this repository. Its only job is to receive the Sender's instruction and render the
+in-repo Cast view for the target Room. Platform-specific (a Chromecast receiver is not a Roku channel).
+
+### Cast view
+
+The read-only display of a Room's current state intended for a television: whose turn is next,
+the current action, and the Room background/video. It is the same regardless of which platform
+delivered it, and can also be reached directly by opening the Room's cast URL in a TV browser.
+"Read-only" means it shows state but cannot drive the game (no remote roll).

--- a/docs/engineering/enhancement-opportunities.md
+++ b/docs/engineering/enhancement-opportunities.md
@@ -6,15 +6,6 @@ Companion to [README.md](README.md). A candid, engineering-honest list of curren
 
 ---
 
-## Casting & TV
-
-Today only **Chromecast** is integrated (custom receiver `1227B8DE`). Gaps:
-
-- **No AirPlay support.** Apple users can only OS-mirror. Could add `x-webkit-airplay` attributes to `<video>` elements and an AirPlay route picker for Safari, at least for direct-video backgrounds.
-- **No Roku / Fire TV / smart-TV apps.** Options to consider, in rough effort order: (a) document the "open `/<room>/cast` in the TV browser" path in-app; (b) a lightweight Roku/Fire TV channel that just loads the cast URL; (c) DIAL-based launch.
-- **Cast receiver app ID is hardcoded** (`1227B8DE`) and the **receiver HTML is hosted externally** (not in this repo). Document where it lives and how it's registered/updated, or bring it into the repo.
-- **Cast view is read-only.** It shows state but can't drive the game (no remote roll). A richer receiver could show more (chat, video tiles, scores).
-
 ## Media
 
 - **Reddit slideshow depends on third-party CORS proxies** (`r.jina.ai`, `allorigins`, `corsproxy.io`). These are availability and privacy risks; a small first-party proxy/Cloud Function would be more reliable.

--- a/src/components/CastButton/__tests__/CastButton.test.tsx
+++ b/src/components/CastButton/__tests__/CastButton.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { BrowserRouter } from 'react-router-dom';
 import CastButton from '../index';
@@ -88,24 +88,19 @@ describe('CastButton Core Functionality', () => {
     });
   });
 
-  describe('Cast Message Functionality', () => {
-    it('should create proper cast URL', async () => {
+  describe('Session control', () => {
+    it('requests a cast session when clicked while not casting', async () => {
       render(
         <TestWrapper>
           <CastButton />
         </TestWrapper>
       );
 
-      await waitFor(() => {
-        expect(screen.getByRole('button')).toBeInTheDocument();
-      });
+      const button = await screen.findByRole('button');
+      fireEvent.click(button);
 
-      // The component should use the room ID from useParams
-      // and create URLs like: ${window.location.origin}/TESTROOM/cast
-      expect(screen.getByRole('button')).toBeInTheDocument();
-
-      // This test verifies the basic structure is working
-      // The actual message sending is tested through integration
+      expect(mockRequestSession).toHaveBeenCalledTimes(1);
+      expect(mockEndCurrentSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/CastButton/index.tsx
+++ b/src/components/CastButton/index.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import CastConnectedIcon from '@mui/icons-material/CastConnected';
 import CastIcon from '@mui/icons-material/Cast';
 import { t } from 'i18next';
+import { CAST_NAMESPACE, buildCastUrl, buildLoadMessage } from '@/helpers/cast';
 
 // Global flags to track Cast API state
 window.__castApiInitialized = window.__castApiInitialized || false;
@@ -32,12 +33,8 @@ export default function CastButton(): JSX.Element | null {
   const sendCastMessage = useCallback(
     (session: any) => {
       try {
-        const castUrl = `${window.location.origin}/${room}/cast`;
-
-        session.sendMessage('urn:x-cast:com.blitzedout.app', {
-          type: 'LOAD',
-          url: castUrl,
-        });
+        const castUrl = buildCastUrl(window.location.origin, room ?? '');
+        session.sendMessage(CAST_NAMESPACE, buildLoadMessage(castUrl));
       } catch (error) {
         console.error('Error sending cast message:', error);
       }

--- a/src/helpers/__tests__/cast.test.ts
+++ b/src/helpers/__tests__/cast.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CAST_NAMESPACE,
+  buildCastUrl,
+  buildLoadMessage,
+  detectCastEnvironment,
+  parseActionCard,
+} from '../cast';
+import { Message } from '@/types/Message';
+
+const makeMessage = (over: Partial<Message> = {}): Message =>
+  ({
+    id: 'm1',
+    type: 'actions',
+    uid: 'user1',
+    timestamp: '2026-06-06T00:00:00.000Z',
+    displayName: 'Alex',
+    text: 'Rolled a 3\nType: Spanking\nActivity: 10 swats',
+    ...over,
+  }) as Message;
+
+describe('buildCastUrl', () => {
+  it('joins origin and room into the cast route', () => {
+    expect(buildCastUrl('https://blitzedout.com', 'ABCDE')).toBe(
+      'https://blitzedout.com/ABCDE/cast'
+    );
+  });
+
+  it('does not duplicate slashes when origin has a trailing slash', () => {
+    expect(buildCastUrl('https://blitzedout.com/', 'ABCDE')).toBe(
+      'https://blitzedout.com/ABCDE/cast'
+    );
+  });
+});
+
+describe('buildLoadMessage', () => {
+  it('produces a LOAD payload carrying the cast url', () => {
+    expect(buildLoadMessage('https://blitzedout.com/ABCDE/cast')).toEqual({
+      type: 'LOAD',
+      url: 'https://blitzedout.com/ABCDE/cast',
+    });
+  });
+
+  it('exposes the app cast namespace', () => {
+    expect(CAST_NAMESPACE).toBe('urn:x-cast:com.blitzedout.app');
+  });
+});
+
+describe('parseActionCard', () => {
+  it('extracts displayName, type, and activity from a structured action message', () => {
+    expect(parseActionCard(makeMessage())).toEqual({
+      displayName: 'Alex',
+      type: 'Spanking',
+      activity: '10 swats',
+    });
+  });
+
+  it('returns an empty card when there is no displayName', () => {
+    expect(parseActionCard(makeMessage({ displayName: undefined }))).toEqual({});
+  });
+
+  it('tolerates a message missing the type/activity lines', () => {
+    expect(parseActionCard(makeMessage({ text: 'Rolled a 3' }))).toEqual({
+      displayName: 'Alex',
+      type: undefined,
+      activity: undefined,
+    });
+  });
+});
+
+describe('detectCastEnvironment', () => {
+  it('is true when a Cast receiver context is present', () => {
+    expect(
+      detectCastEnvironment({ userAgent: 'Mozilla', search: '', hasReceiverContext: true })
+    ).toBe(true);
+  });
+
+  it('is true for a Chromecast user agent (CrKey)', () => {
+    expect(
+      detectCastEnvironment({
+        userAgent: 'Mozilla CrKey/1.0',
+        search: '',
+        hasReceiverContext: false,
+      })
+    ).toBe(true);
+  });
+
+  it('is true when the query string flags a receiver', () => {
+    expect(
+      detectCastEnvironment({
+        userAgent: 'Mozilla',
+        search: '?receiver=1',
+        hasReceiverContext: false,
+      })
+    ).toBe(true);
+  });
+
+  it('is false for an ordinary browser', () => {
+    expect(
+      detectCastEnvironment({ userAgent: 'Mozilla', search: '', hasReceiverContext: false })
+    ).toBe(false);
+  });
+});

--- a/src/helpers/cast.ts
+++ b/src/helpers/cast.ts
@@ -1,0 +1,57 @@
+import { ActionCard } from '@/types/cast';
+import { Message } from '@/types/Message';
+
+/** Custom Cast message namespace shared by the Sender and the Receiver shell. */
+export const CAST_NAMESPACE = 'urn:x-cast:com.blitzedout.app';
+
+export interface CastLoadMessage {
+  type: 'LOAD';
+  url: string;
+}
+
+export interface CastEnvironmentInputs {
+  userAgent: string;
+  search: string;
+  hasReceiverContext: boolean;
+}
+
+/** Platform-agnostic Cast view URL for a Room. This is the seam every TV path loads. */
+export function buildCastUrl(origin: string, room: string): string {
+  return `${origin.replace(/\/$/, '')}/${room}/cast`;
+}
+
+/** Sender → Receiver instruction telling the TV which Cast view URL to render. */
+export function buildLoadMessage(url: string): CastLoadMessage {
+  return { type: 'LOAD', url };
+}
+
+/**
+ * Parse a structured action Message into the card the Cast view displays.
+ * Expected text shape: line 0 is the roll, then `Type: ...` and `Activity: ...`.
+ */
+export function parseActionCard(lastAction: Message): ActionCard {
+  const { text, displayName } = lastAction;
+  if (!displayName) return {};
+
+  const splitText = text?.split('\n');
+  const [typeString, activityString] = splitText?.slice(1) || [];
+  const type = typeString?.split(':')[1]?.trim();
+  const activity = activityString?.split(':')[1]?.trim();
+
+  return { displayName, type, activity };
+}
+
+/** Whether the current page is rendering inside a TV/cast receiver rather than a normal browser. */
+export function detectCastEnvironment({
+  userAgent,
+  search,
+  hasReceiverContext,
+}: CastEnvironmentInputs): boolean {
+  const isChromecastAgent = userAgent.includes('CrKey') || userAgent.includes('TV');
+  return (
+    hasReceiverContext ||
+    isChromecastAgent ||
+    search.includes('chromecast') ||
+    search.includes('receiver')
+  );
+}

--- a/src/views/Cast/index.tsx
+++ b/src/views/Cast/index.tsx
@@ -4,8 +4,7 @@ import '@/types/window';
 import { Box, Button, Divider, Grid, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 
-import { ActionCard } from '@/types/cast';
-import { Message } from '@/types/Message';
+import { detectCastEnvironment, parseActionCard } from '@/helpers/cast';
 import RoomBackground from '@/components/RoomBackground';
 import ToastAlert from '@/components/ToastAlert';
 import { Trans } from 'react-i18next';
@@ -20,18 +19,6 @@ import getPrivateRoomBackground from '@/helpers/getPrivateRoomBackground';
 import useTurnIndicator from '@/hooks/useTurnIndicator';
 
 const ACTION_TYPE = 'actions';
-
-const actionCard = (lastAction: Message): ActionCard => {
-  const { text, displayName } = lastAction;
-  if (!displayName) return {};
-
-  const splitText = text?.split('\n');
-  const [typeString, activityString] = splitText?.slice(1) || [];
-  const type = typeString?.split(':')[1]?.trim();
-  const activity = activityString?.split(':')[1]?.trim();
-
-  return { displayName, type, activity };
-};
 
 export default function Cast() {
   const { id: room } = useParams<{ id: string }>();
@@ -122,17 +109,12 @@ export default function Cast() {
 
   useEffect(() => {
     // Check if we're running in a Cast receiver environment
-    const isCastEnvironment = window.cast?.framework?.CastReceiverContext;
-    const userAgent = navigator.userAgent;
-    const isChromecast = userAgent.includes('CrKey') || userAgent.includes('TV');
     const isInIframe = window.self !== window.top;
-
-    // More robust detection for cast environment
-    const isActuallyCasting =
-      isCastEnvironment ||
-      isChromecast ||
-      window.location.search.includes('chromecast') ||
-      window.location.search.includes('receiver');
+    const isActuallyCasting = detectCastEnvironment({
+      userAgent: navigator.userAgent,
+      search: window.location.search,
+      hasReceiverContext: !!window.cast?.framework?.CastReceiverContext,
+    });
 
     if (isActuallyCasting) {
       document.body.classList.add('cast-receiver-mode');
@@ -232,7 +214,7 @@ export default function Cast() {
     );
   }
 
-  const { displayName, type, activity } = actionCard(lastAction);
+  const { displayName, type, activity } = parseActionCard(lastAction);
 
   return (
     <Box


### PR DESCRIPTION
## What

Makes the Chromecast casting logic testable and pins down its vocabulary, as a foundation for any future TV-platform expansion.

- **Extract pure helpers** → `src/helpers/cast.ts`, written test-first (red→green):
  - `buildCastUrl(origin, room)` — the platform-agnostic `/<room>/cast` seam every TV path loads
  - `buildLoadMessage(url)` + `CAST_NAMESPACE` — the Sender→Receiver `LOAD` payload
  - `parseActionCard(message)` — action-message → display card (moved out of the Cast view)
  - `detectCastEnvironment({ userAgent, search, hasReceiverContext })` — receiver-vs-browser detection
- **Rewire** `CastButton` and the `Cast` view to consume the helpers. Behavior unchanged.
- **Replace** the hollow `CastButton` render-only test with a real session-request interaction test.
- **Docs:** add canonical cast terms to `CONTEXT.md` (**Cast Sender** / **Receiver shell** / **Cast view**) and remove the now-redundant *Casting & TV* section from `enhancement-opportunities.md`.

## Why

The Sender was welded to `window.cast` globals with a test that only asserted the button rendered. The pure logic (URL/message builders, action parser, env-detect) is now isolated and covered, per the "pure function + data bundle" pattern in CLAUDE.md.

## Key finding (recorded in commit history)

App-driven AirPlay has **no** equivalent to Chromecast's URL/web-receiver model — it streams a single media element only. The reusable expansion seam is "load the `/cast` URL on the TV" (Chromecast, TV browser, future native Roku/Fire/tvOS channel); AirPlay can't reach Cast-view parity and would be video-background-only.

## Not addressed (dropped from backlog with the doc section)

Where the external Receiver shell HTML (app ID `1227B8DE`) is hosted/registered remains an open question; AirPlay, Roku/Fire, and remote-roll on the read-only Cast view remain unbuilt.

## Test plan

- `src/helpers/__tests__/cast.test.ts` — 11 new tests, green
- `src/components/CastButton/__tests__/CastButton.test.tsx` — interaction test, green
- `npm run type-check` clean; pre-existing `gameBoard.test.ts` failure is unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)