### PR TITLE
docs: resolve realtime/video enhancements + consolidate MAX_PEERS

### DIFF
--- a/docs/engineering/enhancement-opportunities.md
+++ b/docs/engineering/enhancement-opportunities.md
@@ -33,27 +33,6 @@ Companion to [README.md](README.md). A candid, engineering-honest list of curren
 - **Online mode degrades hard offline** (rooms/chat/presence/video all need network). Some of this is inherent, but graceful messaging and queued chat could improve UX.
 - **Firestore `persistentLocalCache` is slower** than the deprecated API (noted in ADR-0001); acceptable because Dexie is primary, but watch perf on large message histories.
 
-## Realtime / video
-
-- **4-peer cap** on WebRTC — fine for the use case, but a mesh topology won't scale beyond that; an SFU would be needed for larger rooms.
-- **TURN credentials are static in the bundle**. Dynamic per-session credentials would reduce abuse risk.
-- **Signaling cleanup relies on a scheduled function** — if it fails, stale signaling data accumulates (no TTL on RTDB paths).
-
-## Performance
-
-- **Bundle audit tooling exists**: `rollup-plugin-visualizer` is wired into `vite.config.ts`, gated behind `ANALYZE=true npm run build` (writes `bundle-stats.html`, gitignored). Run it periodically as features grow.
-- **Initial JS is code-split.** Routes (`Cast`, `Room`, `UnauthenticatedApp`) and heavy on-demand dialogs (`GameGuide`→react-markdown, `GameStatistics`, `ManageGameBoards`, `Schedule`, `GameSettingsDialog`, `AppSettingsDialog`, `CustomTilesDialog`, `AuthDialog`) load lazily via `lazyWithRetry`. Main entry chunk is ~97 KB gzipped (was ~374 KB before splitting). `dice-box-threejs` (~140 KB gz) is its own chunk, preloaded on idle. Watch for `INEFFECTIVE_DYNAMIC_IMPORT` warnings at build time — a lazy target also imported statically elsewhere won't actually split.
-- **Sounds (~12 MB dicebox files) aren't precached** — first play needs network. The `navigateFallbackDenylist` deliberately excludes audio from the SW precache; selectively runtime-cache the few most-used short dicehit sounds via Workbox if first-play latency matters. (Synthesized UI sounds in `gameSounds.ts` are oscillator-based, no files.)
-- **AudioContext is now a reused singleton** (`audioContext.ts`); `gameSounds.ts` no longer creates/closes a context per sound (avoids the ~6-context browser cap and per-roll latency).
-- **Message store keeps 24h of messages** in localStorage + Zustand, bounded by time not count — large/busy rooms could bloat; consider a hard count cap or windowing.
-
-## Security (cross-reference)
-
-The full list and priorities are in [security.md](security.md#prioritized-hardening-backlog). Headlines:
-
-1. Scope **RTDB presence reads** and **signaling writes**.
-2. Validate **background media URLs** before iframe embedding. _(Schedule/custom-action/board URL + string-size validation is done.)_
-
 ## Tooling & docs
 
 - **No automated dependency audit** in the documented workflow — add `npm audit` to CI.

--- a/src/components/VideoCall/VideoGrid/index.tsx
+++ b/src/components/VideoCall/VideoGrid/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography, Tooltip } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { MAX_PEERS } from '@/config/webrtc';
 import VideoTile from '../VideoTile';
 
 interface ParticipantData {
@@ -39,7 +40,6 @@ const VideoGrid = ({ participants }: VideoGridProps) => {
     );
   }
 
-  const MAX_PEERS = 4;
   const isAtLimit = participantCount >= MAX_PEERS;
 
   return (

--- a/src/config/webrtc.ts
+++ b/src/config/webrtc.ts
@@ -4,6 +4,10 @@ export interface IceServer {
   credential?: string;
 }
 
+// Mesh topology cap — beyond this, per-peer connection count crashes browsers.
+// For larger groups the UI redirects users to an SFU-based service (Discord/Jitsi/Zoom).
+export const MAX_PEERS = 4;
+
 const METERED_USERNAME = import.meta.env.VITE_METERED_USERNAME;
 const METERED_CREDENTIAL = import.meta.env.VITE_METERED_CREDENTIAL;
 

--- a/src/stores/videoCallStore.ts
+++ b/src/stores/videoCallStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import SimplePeer from 'simple-peer';
 import { getDatabase, ref, onValue, off } from 'firebase/database';
 import { firebaseSignaling, SignalData } from '@/services/firebaseSignaling';
-import { ICE_SERVERS } from '@/config/webrtc';
+import { ICE_SERVERS, MAX_PEERS } from '@/config/webrtc';
 
 const createMediaError = (
   error: unknown
@@ -430,9 +430,6 @@ export const useVideoCallStore = create<VideoCallState>((set, get) => ({
       }
 
       lastUserIds = userIds;
-
-      // Limit maximum connections to prevent browser crashes
-      const MAX_PEERS = 4;
 
       // Clean up disconnected peers first
       peers.forEach((peerData, peerId) => {


### PR DESCRIPTION
## What

Groomed the **Realtime / video** section of `enhancement-opportunities.md` — analyzed each bullet against live source, resolved all three, and removed the section.

| Bullet | Verdict |
|---|---|
| **4-peer cap / SFU** | Ignore SFU — intentional design; UI already redirects users to Discord/Jitsi/Zoom at the limit. |
| **TURN creds static in bundle** | **Defer** — proper fix needs a Cloud Function handing out ephemeral Metered creds (the API key can't just move to the bundle). Risk stays tracked in `security.md:89` (rotate periodically). |
| **Signaling cleanup** | Already mitigated — two layers: client `onDisconnect` + delayed deletes (5s/30s) **and** the scheduled cleanup function (5min/2min TTL). Stale data only if both fail; payload is tiny. |

## Code change

The only actionable win: `MAX_PEERS = 4` was duplicated in `videoCallStore.ts` and `VideoGrid/index.tsx`. Consolidated into `src/config/webrtc.ts` next to `ICE_SERVERS`, imported by both call sites.

## Also included

Pre-existing uncommitted removals of the **Performance** and **Security cross-reference** doc sections (companion to shipped #1076 perf code-split / #1078 firestore validation). `public/sitemap.xml` lastmod bump left out of scope.

## Verification

- `npm run type-check` clean
- `eslint` clean on changed files
- `webrtc.test.ts` 6/6 pass
- No doc links referenced the removed `#realtime--video` anchor; other "4 peers" feature-doc mentions left as-is (still accurate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)