### PR TITLE
fix: show next player name in roll dialog for shared-device mode

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://blitzed-out.com/</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://blitzed-out.com/PUBLIC</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-06-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/components/ActionCard/ActionCard.test.tsx
+++ b/src/components/ActionCard/ActionCard.test.tsx
@@ -2,6 +2,12 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ActionCard from './index';
 
+vi.mock('react-i18next', () => ({
+  Trans: ({ i18nKey, values }: { i18nKey: string; values?: Record<string, unknown> }) =>
+    values?.player != null ? `${i18nKey}:${values.player}` : i18nKey,
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+
 vi.mock('@/hooks/useBreakpoint', () => ({
   default: vi.fn(() => false),
 }));
@@ -72,5 +78,28 @@ describe('ActionCard', () => {
     };
     render(<ActionCard {...defaultProps} nextPlayer={nextPlayer} />);
     expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('names the next player (not "your turn") in shared-device mode', () => {
+    const nextPlayer = {
+      uid: 'local-2',
+      displayName: 'sarah',
+      isSelf: true,
+      isFinished: false,
+    };
+    render(<ActionCard {...defaultProps} nextPlayer={nextPlayer} isLocalRoom />);
+    expect(screen.getByText('nextPlayersTurn:sarah')).toBeInTheDocument();
+    expect(screen.queryByText('yourTurn')).not.toBeInTheDocument();
+  });
+
+  it('shows "your turn" when self is next and not a shared device', () => {
+    const nextPlayer = {
+      uid: '123',
+      displayName: 'NextPerson',
+      isSelf: true,
+      isFinished: false,
+    };
+    render(<ActionCard {...defaultProps} nextPlayer={nextPlayer} />);
+    expect(screen.getByText('yourTurn')).toBeInTheDocument();
   });
 });

--- a/src/components/ActionCard/index.tsx
+++ b/src/components/ActionCard/index.tsx
@@ -20,6 +20,7 @@ interface ActionCardProps {
   stopAutoClose?: () => void;
   nextPlayer: Player | null;
   isMyMessage?: boolean;
+  isLocalRoom?: boolean;
 }
 
 const AUTO_CLOSE_SECONDS = 20;
@@ -32,6 +33,7 @@ export default function ActionCard({
   stopAutoClose = () => null,
   nextPlayer = null,
   isMyMessage = false,
+  isLocalRoom = false,
 }: ActionCardProps): JSX.Element {
   const { t } = useTranslation();
   const isMobile = useBreakpoint();
@@ -227,7 +229,7 @@ export default function ActionCard({
                               textAlign: isMobile ? 'center' : 'right',
                             }}
                           >
-                            {nextPlayer.isSelf ? (
+                            {nextPlayer.isSelf && !isLocalRoom ? (
                               <Trans i18nKey="yourTurn" />
                             ) : (
                               <Trans i18nKey="nextPlayersTurn" values={{ player }} />

--- a/src/components/PopupMessage/index.tsx
+++ b/src/components/PopupMessage/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import ActionCard from '@/components/ActionCard';
 import useSoundAndDialog, { DialogResult } from '@/hooks/useSoundAndDialog';
 import useTurnIndicator from '@/hooks/useTurnIndicator';
+import { useLocalPlayers } from '@/hooks/useLocalPlayers';
 import { useTranslation } from 'react-i18next';
 import { Message } from '@/types/Message';
 
@@ -9,6 +10,8 @@ const PopupMessage = (): JSX.Element | null => {
   const { t } = useTranslation();
   const { message, setMessage, isMyMessage }: DialogResult = useSoundAndDialog();
   const nextPlayer = useTurnIndicator(message as Message);
+  const { hasLocalPlayers, isLocalPlayerRoom } = useLocalPlayers();
+  const isLocalRoom = hasLocalPlayers && isLocalPlayerRoom;
 
   // Keep track of the last valid message for exit animation
   const [lastMessage, setLastMessage] = useState<Message | null>(null);
@@ -64,6 +67,7 @@ const PopupMessage = (): JSX.Element | null => {
       stopAutoClose={stopAutoClose}
       nextPlayer={nextPlayer}
       isMyMessage={isMyMessage}
+      isLocalRoom={isLocalRoom}
     />
   );
 };


### PR DESCRIPTION
## Problem

In shared-device / local multiplayer mode (multiple players on one device), the roll-result dialog always printed **"YOUR TURN!!!"** for who goes next, instead of naming the next player. The non-dialog turn toast already showed the correct name.

## Root cause

`ActionCard` (dialog) and the standalone `TurnIndicator` (toast) both read the next player from `useTurnIndicator`, which carries `isSelf = localPlayer.isActive` for local players. In local mode the active flag advances before `ActionCard` renders, so the next player is already active (`isSelf=true`) → "YOUR TURN". The toast happens to render before the advance, so it was correct. A shared device has no single "self".

## Fix

Scoped to the dialog **label** only:
- `PopupMessage` detects the local room (`hasLocalPlayers && isLocalPlayerRoom`) and passes `isLocalRoom` to `ActionCard`.
- `ActionCard` branch becomes `nextPlayer.isSelf && !isLocalRoom ? yourTurn : nextPlayersTurn` → local mode always shows **"Next player: <name>"**.

`useTurnIndicator` and `TurnIndicator` gating are left untouched, so the working toast path can't be perturbed (avoids unmasking a duplicate toast in `playerDialog=ON, othersDialog=OFF`). Solo / individual-device / online still show "YOUR TURN" when you are next.

No i18n changes (reuses existing `nextPlayersTurn`).

## Tests

`ActionCard.test.tsx` — local + self-next → name (not "your turn"); non-local + self-next → "your turn" (regression guard). 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)