### PR TITLE
ci: run lint, test, and build jobs in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: lint
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -72,7 +71,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Use Node.js 22.x


### PR DESCRIPTION
## What

Removes the serial `needs:` chain (`lint → test → build`) in `.github/workflows/ci.yml` so all three jobs run on concurrent runners.

## Why

Each job already does its own `checkout` + `setup-node` + `npm ci` — it's fully self-contained. The `needs:` dependency only forced serial execution; it shared no setup. Dropping it parallelizes with no other changes.

## Effect

- **Before:** wall-clock ≈ `3 × install + lint + test + build` (serial)
- **After:** wall-clock ≈ `install + max(lint, test, build)` (parallel)

Trade-off: 3× install minutes, but runners overlap so no added wall-clock. All three now report independently — every failure surfaces in one run instead of fail-fast hiding later steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)