### PR TITLE
feat(sync): real-time cross-device pull + last-writer-wins for content

### DIFF
--- a/docs/engineering/data-and-sync.md
+++ b/docs/engineering/data-and-sync.md
@@ -69,7 +69,19 @@ Before merging, `syncService.ts` runs a duplicate-tile cleanup to undo a histori
 
 **Conditions:** sync only runs for authenticated, **non-anonymous** users. All cloud data is scoped to `user-data/{uid}` — no cross-user visibility there.
 
-**Multi-device:** logging in with the same account on another device returns the same UID; a sync pulls `user-data/{uid}` into that device's Dexie. Local Dexie isn't auto-pushed between devices instantly — it reconciles on sync (middleware-debounced, manual, or periodic).
+**Multi-device:** logging in with the same account on another device returns the same UID; a sync pulls `user-data/{uid}` into that device's Dexie.
+
+**Real-time pull + last-writer-wins.** Non-anonymous sessions attach an `onSnapshot` listener to `user-data/{uid}` (`subscribeToUserData` in `syncService.ts`, wired in `useAuthSync`), so a change pushed from one device reflects on the others within seconds rather than waiting for the periodic/debounced cycle. Push stays debounced (~2 s). Conflicts resolve last-writer-wins via a per-record `updatedAt` (Unix ms) on custom tiles and game boards (`SyncBase.remoteWins`, strict `>`). The push remains debounced; the listener only pulls.
+
+Loop prevention (push→pull→apply→push) relies on three guards: the snapshot handler skips events with `metadata.hasPendingWrites` (our own writes); an apply-phase suppression flag in `syncMiddleware` (`beginSyncApply`/`endSyncApply`) stops sync-engine Dexie writes from scheduling an echo push; and the entity merges only push back when something actually changed.
+
+**Stated limitations of the LWW/real-time model:**
+
+- **No incremental delete propagation.** The `user-data/{uid}` doc stores arrays with no tombstones, so a tile/board deleted on one device is re-added when another device merges. Deletes only propagate via `forceSync`/full-replace.
+- **Client-clock based.** `updatedAt` is stamped with `Date.now()` at write time; with cross-device clock skew the faster-clock device wins regardless of true edit order.
+- **Settings and custom groups are excluded from LWW.** Settings keep last-sync-wins (whole-object LWW would drop a field on concurrent edits); custom groups remain adds-only on merge (their identity is `name+locale+gameMode` and field edits are rare). Both still reconcile on `forceSync`.
+- **No Dexie schema bump.** `updatedAt` is a non-indexed field; pre-existing rows adopt a timestamp on their next local edit and fall back to legacy (apply-remote) reconciliation until then.
+- **`activateBoard` doesn't bump `updatedAt`** (active-board flips are device-local and don't propagate via LWW).
 
 ---
 

--- a/docs/engineering/enhancement-opportunities.md
+++ b/docs/engineering/enhancement-opportunities.md
@@ -19,8 +19,8 @@ Companion to [README.md](README.md). A candid, engineering-honest list of curren
 ## Sync, accounts & offline
 
 - **Anonymous accounts are single-device and unrecoverable.** Losing browser storage loses content unless exported. A lightweight "backup code"/email-link recovery for anonymous users would help.
-- **Local Dexie isn't pushed cross-device in real time** — reconciliation is debounce/manual/periodic. Conflict resolution is per-entity merge; concurrent edits on two devices can surprise. Consider last-writer-wins timestamps or CRDT-ish merge for boards/settings.
-- **Online mode degrades hard offline** (rooms/chat/presence/video all need network). Some of this is inherent, but graceful messaging and queued chat could improve UX.
+- **Cross-device sync is real-time + LWW for content, but partial.** A per-user `onSnapshot` listener now pulls changes live, and custom tiles + game boards resolve last-writer-wins via `updatedAt` (see [data-and-sync.md](data-and-sync.md#sync-engine)). Still open: settings and custom groups are excluded from LWW; deletes don't propagate incrementally (no tombstones — `forceSync` only); LWW is client-clock based. A tombstone model and field-level settings merge would close the gaps.
+- **Online mode still needs network for presence/video.** Graceful offline messaging + queued-chat feedback are now in place (offline banner, optimistic pending messages); rooms/presence/video remain inherently network-dependent.
 
 ## Tooling & docs
 

--- a/src/hooks/useAuthSync.ts
+++ b/src/hooks/useAuthSync.ts
@@ -61,7 +61,10 @@ export function useAuthSync(user: User | null) {
   useEffect(() => {
     if (!user || user.isAnonymous) {
       import('@/services/syncService')
-        .then(({ stopPeriodicSync }) => stopPeriodicSync())
+        .then(({ stopPeriodicSync, stopUserDataSubscription }) => {
+          stopPeriodicSync();
+          stopUserDataSubscription();
+        })
         .catch(() => undefined);
       return;
     }
@@ -72,11 +75,23 @@ export function useAuthSync(user: User | null) {
       syncTimeoutRef.current = setTimeout(async () => {
         setSyncStatus({ syncing: true, lastSync: null });
         try {
-          const { syncDataFromFirebase, startPeriodicSync } =
-            await import('@/services/syncService');
+          const {
+            syncDataFromFirebase,
+            syncAllDataToFirebase,
+            startPeriodicSync,
+            subscribeToUserData,
+          } = await import('@/services/syncService');
           await syncDataFromFirebase();
+          // One-shot push of the merged union after the initial pull. This uploads
+          // local-only content that was never individually pushed (e.g. tiles
+          // created while anonymous, before logging into this account). Loop-safe:
+          // the entity merges only push back on change, so the resulting snapshot
+          // pulls, finds nothing newer, and stops.
+          await syncAllDataToFirebase();
           setSyncStatus({ syncing: false, lastSync: new Date() });
           startPeriodicSync();
+          // Real-time pull: reflect changes from other devices as they happen.
+          subscribeToUserData();
         } catch {
           setSyncStatus({ syncing: false, lastSync: null });
         } finally {
@@ -100,6 +115,9 @@ export function useAuthSync(user: User | null) {
         clearTimeout(deferTimeoutRef.current);
         deferTimeoutRef.current = null;
       }
+      import('@/services/syncService')
+        .then(({ stopUserDataSubscription }) => stopUserDataSubscription())
+        .catch(() => undefined);
     };
   }, [user]);
 

--- a/src/services/__tests__/syncService.test.ts
+++ b/src/services/__tests__/syncService.test.ts
@@ -6,8 +6,9 @@ import {
 } from '@/stores/customTiles';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { deleteCustomGroup, getCustomGroups, importCustomGroups } from '@/stores/customGroups';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import {
+  subscribeToUserData,
   syncCustomGroupsToFirebase,
   syncCustomTilesToFirebase,
   syncDataFromFirebase,
@@ -255,8 +256,13 @@ describe('syncService', () => {
         ) {
           return [{ id: 100, isEnabled: 1, isCustom: 0 }] as any;
         }
+        // Locally-disabled defaults query (matchesLocal / resetDisabledDefaults):
+        // nothing is disabled locally yet, so the remote set genuinely differs.
+        if (filters?.isCustom === 0 && filters?.isEnabled === 0) {
+          return [];
+        }
         // For applyDisabledDefaults - return all default tiles
-        if (filters?.isCustom === 0 && !filters?.isEnabled) {
+        if (filters?.isCustom === 0) {
           return [
             {
               id: 100,
@@ -774,6 +780,56 @@ describe('syncService', () => {
 
       // Verify disabled defaults are applied to existing default tiles
       expect(updateCustomTile).toHaveBeenCalledWith(300, { isEnabled: 0 });
+    });
+  });
+
+  describe('subscribeToUserData (real-time pull)', () => {
+    let capturedSnapshotHandler: ((snap: any) => void) | null;
+
+    beforeEach(() => {
+      capturedSnapshotHandler = null;
+      vi.mocked(onSnapshot).mockImplementation((_ref: any, next: any) => {
+        capturedSnapshotHandler = next;
+        return () => undefined;
+      });
+      // Empty doc → orchestrator reads it via getDoc; lets us detect a pull.
+      vi.mocked(getDoc).mockResolvedValue({ exists: () => true, data: () => ({}) } as any);
+    });
+
+    it('does not register a listener for anonymous users', () => {
+      vi.mocked(getAuth).mockReturnValue({
+        currentUser: { uid: 'x', isAnonymous: true },
+      } as any);
+      subscribeToUserData();
+      expect(onSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('ignores snapshots from our own pending writes (echo guard)', async () => {
+      subscribeToUserData();
+      expect(onSnapshot).toHaveBeenCalledTimes(1);
+
+      capturedSnapshotHandler?.({
+        metadata: { hasPendingWrites: true },
+        exists: () => true,
+        data: () => ({}),
+      });
+      await Promise.resolve();
+
+      expect(getDoc).not.toHaveBeenCalled();
+    });
+
+    it('pulls on a genuine remote change', async () => {
+      subscribeToUserData();
+
+      capturedSnapshotHandler?.({
+        metadata: { hasPendingWrites: false },
+        exists: () => true,
+        data: () => ({}),
+      });
+      // Allow the async syncDataFromFirebase chain (dynamic import) to settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(getDoc).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/sync/__tests__/lww.test.ts
+++ b/src/services/sync/__tests__/lww.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/stores/gameBoard', () => ({
+  getBoards: vi.fn(),
+  upsertBoard: vi.fn(),
+}));
+
+import { SyncBase } from '../base';
+import { GameBoardsSync } from '../gameBoardsSync';
+import { getBoards, upsertBoard } from '@/stores/gameBoard';
+
+describe('SyncBase.remoteWins', () => {
+  it('applies the newer side when both have timestamps (strict)', () => {
+    expect(SyncBase.remoteWins(100, 200)).toBe(true); // remote newer
+    expect(SyncBase.remoteWins(200, 100)).toBe(false); // local newer
+    expect(SyncBase.remoteWins(100, 100)).toBe(false); // tie keeps local (stops loop)
+  });
+
+  it('keeps local when only local has a timestamp (remote is pre-feature)', () => {
+    expect(SyncBase.remoteWins(100, undefined)).toBe(false);
+  });
+
+  it('applies remote when only remote has a timestamp', () => {
+    expect(SyncBase.remoteWins(undefined, 100)).toBe(true);
+  });
+
+  it('applies remote when neither has a timestamp (legacy behavior)', () => {
+    expect(SyncBase.remoteWins(undefined, undefined)).toBe(true);
+  });
+});
+
+describe('GameBoardsSync last-writer-wins', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips a remote board when the local copy is newer', async () => {
+    vi.mocked(getBoards).mockResolvedValue([
+      { id: 1, title: 'B', tiles: [], isActive: 0, tags: [], gameMode: 'online', updatedAt: 500 },
+    ]);
+
+    await GameBoardsSync.syncFromFirebase([
+      { title: 'B', tiles: [], isActive: 0, tags: [], gameMode: 'online', updatedAt: 200 },
+    ]);
+
+    expect(upsertBoard).not.toHaveBeenCalled();
+  });
+
+  it('applies a remote board when it is newer, preserving its timestamp', async () => {
+    vi.mocked(getBoards).mockResolvedValue([
+      { id: 1, title: 'B', tiles: [], isActive: 0, tags: [], gameMode: 'online', updatedAt: 100 },
+    ]);
+    vi.mocked(upsertBoard).mockResolvedValue(1);
+
+    await GameBoardsSync.syncFromFirebase([
+      { title: 'B', tiles: [], isActive: 0, tags: [], gameMode: 'online', updatedAt: 900 },
+    ]);
+
+    expect(upsertBoard).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'B', updatedAt: 900 })
+    );
+  });
+
+  it('applies a remote board that does not exist locally', async () => {
+    vi.mocked(getBoards).mockResolvedValue([]);
+    vi.mocked(upsertBoard).mockResolvedValue(2);
+
+    await GameBoardsSync.syncFromFirebase([
+      { title: 'New', tiles: [], isActive: 0, tags: [], gameMode: 'online', updatedAt: 50 },
+    ]);
+
+    expect(upsertBoard).toHaveBeenCalledWith(expect.objectContaining({ title: 'New' }));
+  });
+});

--- a/src/services/sync/base.ts
+++ b/src/services/sync/base.ts
@@ -59,6 +59,24 @@ export class SyncBase {
   }
 
   /**
+   * Last-writer-wins decision for a single entity.
+   *
+   * Strict `>` so that once two devices converge to the same timestamp neither
+   * keeps re-applying (which would loop the real-time listener). Fallbacks when a
+   * timestamp is absent (data written before this feature shipped):
+   * - local stamped, remote not  → keep local (remote is stale, pre-feature)
+   * - remote stamped, local not  → apply remote
+   * - neither stamped            → apply remote (preserves legacy behavior)
+   */
+  static remoteWins(localTs?: number, remoteTs?: number): boolean {
+    const l = typeof localTs === 'number' ? localTs : null;
+    const r = typeof remoteTs === 'number' ? remoteTs : null;
+    if (l !== null && r !== null) return r > l;
+    if (l !== null) return false;
+    return true;
+  }
+
+  /**
    * Create success result
    */
   static createSuccessResult(itemsProcessed = 0): SyncResult {

--- a/src/services/sync/customGroupsSync.ts
+++ b/src/services/sync/customGroupsSync.ts
@@ -66,8 +66,11 @@ export class CustomGroupsSync extends SyncBase {
       }
     }
 
-    // Sync the merged result back to Firebase
-    await syncCustomGroupsToFirebase();
+    // Only push back when groups were actually added — otherwise the real-time
+    // listener would echo every pull into a push.
+    if (addedCount > 0) {
+      await syncCustomGroupsToFirebase();
+    }
 
     return this.createSuccessResult(addedCount + localGroups.length);
   }

--- a/src/services/sync/customTilesSync.ts
+++ b/src/services/sync/customTilesSync.ts
@@ -70,10 +70,17 @@ export class CustomTilesSync extends SyncBase {
         const matchResult = await TileMatcher.findExistingTile(tile);
 
         if (matchResult.existingTile) {
-          // Update existing tile if needed (only isEnabled can be synced)
-          if (matchResult.existingTile.isEnabled !== tile.isEnabled) {
-            await updateCustomTile(matchResult.existingTile.id!, {
+          const existing = matchResult.existingTile;
+          // Update existing tile if needed (only isEnabled is synced), and only
+          // when the remote copy wins last-writer-wins. Preserve the remote
+          // timestamp so the applied tile doesn't look newer than its source.
+          if (
+            existing.isEnabled !== tile.isEnabled &&
+            this.remoteWins(existing.updatedAt, tile.updatedAt)
+          ) {
+            await updateCustomTile(existing.id!, {
               isEnabled: tile.isEnabled,
+              updatedAt: tile.updatedAt ?? Date.now(),
             });
             updatedCount++;
           }
@@ -88,8 +95,11 @@ export class CustomTilesSync extends SyncBase {
       }
     }
 
-    // Sync the merged result back to Firebase
-    await syncCustomTilesToFirebase();
+    // Only push the merged result back when something actually changed —
+    // otherwise the real-time listener would echo every pull into a push.
+    if (addedCount + updatedCount > 0) {
+      await syncCustomTilesToFirebase();
+    }
 
     return this.createSuccessResult(addedCount + updatedCount + localTiles.length);
   }

--- a/src/services/sync/disabledDefaultsSync.ts
+++ b/src/services/sync/disabledDefaultsSync.ts
@@ -3,14 +3,35 @@
  */
 import { SyncBase } from './base';
 import { resetDisabledDefaults, applyDisabledDefaults } from '../syncService';
+import { getTiles } from '@/stores/customTiles';
 import type { SyncResult } from '@/types/sync';
 
+const disabledKey = (tile: { group_id?: string; intensity: number; action: string }): string =>
+  `${tile.group_id}|${tile.intensity}|${tile.action}`;
+
 export class DisabledDefaultsSync extends SyncBase {
+  /**
+   * Returns true when the local disabled-default set already matches the remote
+   * one, so we can skip the reset+apply churn (and its echo push) entirely.
+   */
+  private static async matchesLocal(disabledDefaults: any[]): Promise<boolean> {
+    const localDisabled = await getTiles({ isCustom: 0, isEnabled: 0 });
+    if (localDisabled.length !== disabledDefaults.length) return false;
+    const localKeys = new Set(localDisabled.map(disabledKey));
+    return disabledDefaults.every((tile) => localKeys.has(disabledKey(tile)));
+  }
+
   /**
    * Sync disabled defaults from Firebase
    */
   static async syncFromFirebase(disabledDefaults: any[]): Promise<SyncResult> {
     try {
+      // No-op when nothing would change — avoids rewriting isEnabled flags on
+      // every sync run for users who have disabled default tiles.
+      if (await this.matchesLocal(disabledDefaults)) {
+        return this.createSuccessResult(0);
+      }
+
       if (!disabledDefaults || disabledDefaults.length === 0) {
         // Still reset any existing disabled defaults to clean state
         await resetDisabledDefaults();

--- a/src/services/sync/gameBoardsSync.ts
+++ b/src/services/sync/gameBoardsSync.ts
@@ -4,7 +4,7 @@ import type { SyncResult } from '@/types/sync';
 /**
  * Game boards synchronization logic
  */
-import { upsertBoard } from '@/stores/gameBoard';
+import { getBoards, upsertBoard } from '@/stores/gameBoard';
 
 export class GameBoardsSync extends SyncBase {
   /**
@@ -16,15 +16,27 @@ export class GameBoardsSync extends SyncBase {
     }
 
     try {
+      // Index local boards by title for last-writer-wins comparison.
+      const localBoards = await getBoards();
+      const localByTitle = new Map(localBoards.map((board) => [board.title, board]));
+
       let importedCount = 0;
       for (const board of gameBoards) {
         try {
+          const local = localByTitle.get(board.title);
+          // Skip when the local board is the winner; otherwise apply the remote
+          // copy and preserve its timestamp.
+          if (local && !this.remoteWins(local.updatedAt, board.updatedAt)) {
+            continue;
+          }
+
           await upsertBoard({
             title: board.title,
             tiles: board.tiles || [],
             tags: board.tags || [],
             gameMode: board.gameMode || 'online',
             isActive: board.isActive || 0,
+            updatedAt: board.updatedAt ?? Date.now(),
           });
           importedCount++;
         } catch (error) {

--- a/src/services/syncMiddleware.ts
+++ b/src/services/syncMiddleware.ts
@@ -5,6 +5,26 @@ interface SyncMiddlewareOptions {
   tables: string[];
 }
 
+/**
+ * Apply-phase suppression. While the sync engine is writing remote changes into
+ * Dexie, those writes must NOT schedule a push back to Firebase — otherwise the
+ * real-time listener would echo our own apply into an infinite push↔pull loop.
+ * The depth counter is checked synchronously at write-time inside `mutate`.
+ */
+let applyDepth = 0;
+
+export function beginSyncApply(): void {
+  applyDepth += 1;
+}
+
+export function endSyncApply(): void {
+  applyDepth = Math.max(0, applyDepth - 1);
+}
+
+export function isApplyingRemoteSync(): boolean {
+  return applyDepth > 0;
+}
+
 interface TimeoutMap {
   [key: string]: ReturnType<typeof setTimeout>;
 }
@@ -88,8 +108,13 @@ export function createSyncMiddleware(
               // First, perform the actual database operation
               const result = await downlevelTable.mutate(req);
 
-              // After successful operation, trigger sync if it's a write operation
-              if (['put', 'add', 'delete', 'deleteRange', 'update'].includes(req.type)) {
+              // After successful operation, trigger sync if it's a write operation.
+              // Skip writes made by the sync engine itself while applying remote
+              // changes (checked synchronously to avoid queueing an echo push).
+              if (
+                !isApplyingRemoteSync() &&
+                ['put', 'add', 'delete', 'deleteRange', 'update'].includes(req.type)
+              ) {
                 // Schedule a sync for this table with debouncing
                 syncDebounce.scheduleSync(tableName);
               }

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -5,7 +5,7 @@ import {
   updateCustomTile,
 } from '@/stores/customTiles';
 import { deleteCustomGroup, getCustomGroups } from '@/stores/customGroups';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 
 import { CustomGroupPull } from '@/types/customGroups';
 import { CustomTilePull } from '@/types/customTiles';
@@ -13,6 +13,7 @@ import { getAuth } from 'firebase/auth';
 import { getBoards } from '@/stores/gameBoard';
 import { getFirestore } from 'firebase/firestore';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { beginSyncApply, endSyncApply } from './syncMiddleware';
 
 // Updated to use inline type instead of separate interface to avoid unused warning
 
@@ -410,7 +411,54 @@ export async function syncDataFromFirebase(
 ): Promise<boolean> {
   // Use the new sync orchestrator for better maintainability
   const { SyncOrchestrator } = await import('./sync/syncOrchestrator');
-  return await SyncOrchestrator.syncFromFirebase(options);
+  // Suppress the sync middleware while applying remote changes so the writes
+  // below don't schedule an echo push back to Firebase.
+  beginSyncApply();
+  try {
+    return await SyncOrchestrator.syncFromFirebase(options);
+  } finally {
+    endSyncApply();
+  }
+}
+
+// Real-time listener over the per-user Firestore document. Pulls remote changes
+// into Dexie as they happen, instead of waiting for the periodic/debounced sync.
+let userDataUnsubscribe: (() => void) | null = null;
+
+export function stopUserDataSubscription(): void {
+  if (userDataUnsubscribe) {
+    userDataUnsubscribe();
+    userDataUnsubscribe = null;
+  }
+}
+
+export function subscribeToUserData(): () => void {
+  const auth = getAuth();
+  const user = auth.currentUser;
+
+  // Anonymous users don't cloud-sync; nothing to subscribe to.
+  if (!user || user.isAnonymous) {
+    return () => undefined;
+  }
+
+  stopUserDataSubscription();
+
+  const userDocRef = doc(db, 'user-data', user.uid);
+  userDataUnsubscribe = onSnapshot(
+    userDocRef,
+    (snapshot) => {
+      // Skip our own just-written changes — applying them would loop.
+      if (snapshot.metadata.hasPendingWrites) return;
+      if (!snapshot.exists()) return;
+      // Re-read + merge through the orchestrator (served from local cache).
+      void syncDataFromFirebase();
+    },
+    (error) => {
+      console.error('Real-time user-data sync error:', error);
+    }
+  );
+
+  return stopUserDataSubscription;
 }
 
 // Variable to store the interval ID for periodic syncing

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -20,6 +20,8 @@ vi.mock('@/services/syncService', () => ({
   startPeriodicSync: () => {},
   stopPeriodicSync: () => {},
   isPeriodicSyncActive: () => false,
+  subscribeToUserData: () => () => {},
+  stopUserDataSubscription: () => {},
 }));
 
 configure({

--- a/src/stores/__tests__/gameBoard.test.ts
+++ b/src/stores/__tests__/gameBoard.test.ts
@@ -161,7 +161,10 @@ describe('gameBoard store', () => {
 
       const result = await addBoard(partialBoard);
 
-      expect(db.gameBoard.add).toHaveBeenCalledWith(partialBoard);
+      expect(db.gameBoard.add).toHaveBeenCalledWith({
+        ...partialBoard,
+        updatedAt: expect.any(Number),
+      });
       expect(result).toBe(newBoardId);
     });
 
@@ -187,6 +190,7 @@ describe('gameBoard store', () => {
       expect(db.gameBoard.update).toHaveBeenCalledWith(mockBoard.id, {
         ...mockBoard,
         ...updatedFields,
+        updatedAt: expect.any(Number),
       });
       expect(result).toBe(updatedRowCount);
     });
@@ -197,7 +201,10 @@ describe('gameBoard store', () => {
 
       const result = await updateBoard(mockBoard);
 
-      expect(db.gameBoard.update).toHaveBeenCalledWith(mockBoard.id, mockBoard);
+      expect(db.gameBoard.update).toHaveBeenCalledWith(mockBoard.id, {
+        ...mockBoard,
+        updatedAt: expect.any(Number),
+      });
       expect(result).toBe(updatedRowCount);
     });
   });
@@ -236,6 +243,7 @@ describe('gameBoard store', () => {
         isActive: 0,
         tags: [],
         gameMode: 'online',
+        updatedAt: expect.any(Number),
       });
     });
 

--- a/src/stores/customTiles.ts
+++ b/src/stores/customTiles.ts
@@ -27,8 +27,20 @@ customTiles.hook(
         );
       }
     }
+
+    // Stamp last-writer-wins timestamp. Sync inserts carry the remote timestamp;
+    // preserve it so the just-pulled tile doesn't look newer than the source.
+    if ((obj as any).updatedAt === undefined) (obj as any).updatedAt = Date.now();
   }
 );
+
+// Bump the last-writer-wins timestamp on every update, unless the caller
+// (the sync engine applying a remote change) supplied an explicit timestamp.
+customTiles.hook('updating', function (this: any, modifications: any) {
+  if (modifications && !('updatedAt' in modifications)) {
+    return { updatedAt: Date.now() };
+  }
+});
 
 export const importCustomTiles = async (
   record: Partial<CustomTile>[]

--- a/src/stores/gameBoard.ts
+++ b/src/stores/gameBoard.ts
@@ -16,14 +16,19 @@ export const getBoard = (id: number): Promise<DBGameBoard | undefined> => {
 };
 
 export const addBoard = async (record: Partial<DBGameBoard>): Promise<number | undefined> => {
-  return gameBoard.add(record as DBGameBoard);
+  // Stamp last-writer-wins timestamp; a sync insert may carry the remote one.
+  const updatedAt = record.updatedAt ?? Date.now();
+  return gameBoard.add({ ...record, updatedAt } as DBGameBoard);
 };
 
 export const updateBoard = async (
   board: DBGameBoard,
   record?: Partial<DBGameBoard>
 ): Promise<number> => {
-  return gameBoard.update(board.id as number, { ...board, ...record });
+  // Bump the timestamp on edit, unless the caller (sync applying a remote board)
+  // supplied an explicit one to preserve.
+  const updatedAt = record?.updatedAt ?? Date.now();
+  return gameBoard.update(board.id as number, { ...board, ...record, updatedAt });
 };
 
 export const upsertBoard = async (record: Partial<DBGameBoard>): Promise<number | undefined> => {
@@ -33,6 +38,7 @@ export const upsertBoard = async (record: Partial<DBGameBoard>): Promise<number 
     isActive: record.isActive === undefined ? 1 : record.isActive,
     tags: record.tags || [],
     gameMode: record.gameMode || 'online',
+    updatedAt: record.updatedAt,
   };
 
   // if we have tiles, we should have a title to go with it.

--- a/src/types/customTiles.ts
+++ b/src/types/customTiles.ts
@@ -6,6 +6,7 @@ export interface CustomTileBase {
   tags: string[];
   isEnabled?: number | boolean;
   isCustom: number;
+  updatedAt?: number; // Unix ms; drives last-writer-wins during sync
 }
 
 // CustomTile interface for pushing (id is optional)

--- a/src/types/gameBoard.ts
+++ b/src/types/gameBoard.ts
@@ -8,6 +8,7 @@ export interface DBGameBoard {
   isActive: number;
   tags: string[];
   gameMode: string;
+  updatedAt?: number; // Unix ms; drives last-writer-wins during sync
 }
 
 export interface Tile {


### PR DESCRIPTION
## Context

From `docs/engineering/enhancement-opportunities.md` → "Sync, accounts & offline":
> **Local Dexie isn't pushed cross-device in real time** — reconciliation is debounce/manual/periodic. Conflict resolution is per-entity merge; concurrent edits on two devices can surprise.

This adds a real-time **pull** listener and per-record **last-writer-wins** for content (custom tiles + game boards), so a change on one device reflects on the others within seconds and concurrent edits resolve deterministically. Push stays debounced (~2s).

Part 2 of 2 from the "Sync, accounts & offline" review (Part 1 = #1083, offline chat UX).

## Changes

- **Real-time pull** — `subscribeToUserData()` attaches `onSnapshot(user-data/{uid})`, wired into `useAuthSync` (non-anonymous only). On a remote change it re-runs the orchestrator merge.
- **Last-writer-wins** — non-indexed `updatedAt` (Unix ms) on `customTiles` + `gameBoard`, stamped on every write (customTiles Dexie hooks; gameBoard store fns). `SyncBase.remoteWins` uses strict `>` with safe fallbacks when a timestamp is absent.
- **Loop prevention** (push→pull→apply→push), three guards:
  1. snapshot handler skips `metadata.hasPendingWrites` (our own writes);
  2. apply-phase suppression flag in `syncMiddleware` (`beginSyncApply`/`endSyncApply`) stops sync-engine Dexie writes from scheduling an echo push (checked synchronously at write-time);
  3. entity merges only push back when something actually changed; `DisabledDefaultsSync` no-ops when local already matches remote.
- **Login union push** — after the initial pull, one-shot `syncAllDataToFirebase()` uploads local-only content that was never individually pushed (e.g. tiles created while anonymous, before logging in). Loop-safe via the merge gate.

## Divergences from the approved plan (all simplifications)

| Approved plan | Shipped | Why |
|---|---|---|
| Dexie **v3** bump + migration | **No bump** | `updatedAt` is non-indexed → no schema-string change needed; also removes the concurrent-agent collision risk. Pre-existing rows adopt a timestamp on next edit (legacy fallback until then). |
| LWW for tiles, **boards, groups** | tiles + boards only | customGroups' `updating` hook unconditionally overwrites `updatedAt`, and groups are near-immutable by identity → kept adds-only. |
| (not in plan) | **suppression flag** + **disabled-defaults diff-gate** | required to actually close the echo loop (the explicit-push gate alone wasn't enough). |

## Stated limitations (documented in `data-and-sync.md`)

- **No incremental delete propagation** — arrays, no tombstones; deletes propagate only via `forceSync`/full-replace.
- **Client-clock LWW** — `Date.now()` at write time; faster-clock device wins under skew.
- **Settings excluded** (keep last-sync-wins; whole-object LWW would drop a field) and **custom groups excluded** (adds-only).
- `activateBoard` doesn't bump `updatedAt` (active-board flips are device-local).

## Tests

- `SyncBase.remoteWins` — all timestamp/fallback branches.
- `GameBoardsSync` LWW — local-newer skip, remote-newer apply (ts preserved), new-board apply.
- `subscribeToUserData` — anon no-op, echo guard (`hasPendingWrites`), genuine pull.

Full suite: 1367 passing · type-check clean · eslint 0 errors.

## Verify manually

Two tabs, same non-anon account: toggle a tile / edit a board in tab A → reflects in tab B within seconds, no manual sync. Concurrent edit on the same entity → newer-timestamp wins. Anonymous→login with local-only tiles → they upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)