### PR TITLE
feat(i18n): localize tile-list placeholders + SW update prompt

### DIFF
--- a/src/components/AllProviders/index.tsx
+++ b/src/components/AllProviders/index.tsx
@@ -3,6 +3,7 @@ import { MigrationProvider } from '@/context/migration';
 import { ScheduleProvider } from '@/context/schedule';
 import { ThemeProvider } from '@/context/theme';
 import MuiProviders from '@/components/MuiProviders';
+import ReloadPrompt from '@/components/ReloadPrompt';
 
 /**
  * Consolidated providers component to reduce Suspense boundary nesting
@@ -13,7 +14,10 @@ export default function AllProviders({ children }: ProvidersProps) {
     <ThemeProvider>
       <MigrationProvider>
         <ScheduleProvider>
-          <MuiProviders>{children}</MuiProviders>
+          <MuiProviders>
+            {children}
+            <ReloadPrompt />
+          </MuiProviders>
         </ScheduleProvider>
       </MigrationProvider>
     </ThemeProvider>

--- a/src/components/ReloadPrompt/index.tsx
+++ b/src/components/ReloadPrompt/index.tsx
@@ -1,0 +1,43 @@
+import { Button, Snackbar } from '@mui/material';
+import { useRegisterSW } from 'virtual:pwa-register/react';
+import { useTranslation } from 'react-i18next';
+import { logger } from '@/utils/logger';
+
+/**
+ * Surfaces a snackbar when a new service worker has been installed and is
+ * waiting. Lets the user reload on their terms so an active game is never
+ * interrupted by an automatic refresh.
+ */
+export default function ReloadPrompt(): JSX.Element | null {
+  const { t } = useTranslation();
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisterError(error) {
+      logger.warn('Service worker registration failed:', error);
+    },
+  });
+
+  if (!needRefresh) {
+    return null;
+  }
+
+  return (
+    <Snackbar
+      open
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      message={t('updateAvailable')}
+      action={
+        <>
+          <Button color="primary" size="small" onClick={() => updateServiceWorker(true)}>
+            {t('reload')}
+          </Button>
+          <Button color="inherit" size="small" onClick={() => setNeedRefresh(false)}>
+            {t('close')}
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -228,6 +228,8 @@
   "finish": "ZIEL",
   "messages": "Nachrichten",
   "close": "Schließen",
+  "updateAvailable": "Eine neue Version ist verfügbar",
+  "reload": "Neu laden",
   "anotherPlayer": "ein anderer Spieler",
   "theCurrentPlayer": "der aktuelle Spieler",
   "aDominant": "ein Dominanter",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -228,6 +228,8 @@
   "finish": "FINISH",
   "messages": "Messages",
   "close": "Close",
+  "updateAvailable": "A new version is available",
+  "reload": "Reload",
   "anotherPlayer": "another player",
   "theCurrentPlayer": "the current player",
   "aDominant": "a dominant",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -228,6 +228,8 @@
   "finish": "FINALIZAR",
   "messages": "Mensajes",
   "close": "Cerrar",
+  "updateAvailable": "Hay una nueva versión disponible",
+  "reload": "Recargar",
   "anotherPlayer": "Otro jugador",
   "theCurrentPlayer": "el jugador actual",
   "aDominant": "un dominante",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -228,6 +228,8 @@
   "finish": "FINIR",
   "messages": "Messages",
   "close": "Fermer",
+  "updateAvailable": "Une nouvelle version est disponible",
+  "reload": "Recharger",
   "anotherPlayer": "un autre joueur",
   "theCurrentPlayer": "le joueur actuel",
   "aDominant": "un dominant",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -229,6 +229,8 @@
   "finish": "समाप्ति",
   "messages": "संदेश",
   "close": "बंद करें",
+  "updateAvailable": "एक नया संस्करण उपलब्ध है",
+  "reload": "पुनः लोड करें",
   "anotherPlayer": "दूसरा खिलाड़ी",
   "theCurrentPlayer": "वर्तमान खिलाड़ी",
   "aDominant": "एक प्रभावी",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -227,6 +227,8 @@
   "finish": "完成",
   "messages": "訊息",
   "close": "關閉",
+  "updateAvailable": "有新版本可用",
+  "reload": "重新載入",
   "anotherPlayer": "另一位玩家",
   "theCurrentPlayer": "當前玩家",
   "aDominant": "一個支配者",

--- a/src/views/CustomTileDialog/ViewCustomTiles/index.tsx
+++ b/src/views/CustomTileDialog/ViewCustomTiles/index.tsx
@@ -27,6 +27,7 @@ import { TileData } from '@/types/viewCustomTiles';
 import { Trans } from 'react-i18next';
 import { ViewCustomTilesProps } from '@/types/customTiles';
 import { getAllAvailableGroups } from '@/stores/customGroups';
+import { localizePlaceholders } from '@/services/placeholderAliasService';
 import { useGameSettings } from '@/stores/settingsStore';
 import { useTranslation } from 'react-i18next';
 
@@ -279,7 +280,7 @@ export default function ViewCustomTiles({
     return (
       <Card sx={{ my: 2 }} key={id}>
         <CardHeader
-          title={action}
+          title={localizePlaceholders(action, settings.locale || 'en')}
           slotProps={{
             title: { variant: 'body1' },
             subheader: { variant: 'body2' },

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />
 
 // Extend the existing Vite ImportMetaEnv with our custom environment variables
 interface ImportMetaEnv {


### PR DESCRIPTION
## Two fixes from an i18n debugging session

### 1. Localize placeholders in the custom-tile list
Default tiles in the manage-custom-actions dialog rendered **raw canonical tokens** (`{dom}`/`{sub}`/`{genital}`), while the placeholder helper chips, edit field, and live preview all localize them. The mismatch was visible in **every non-English language** (es/fr/hi/zh/de) — English looked fine only because its alias map is identity.

**Fix:** `ViewCustomTiles` now renders `localizePlaceholders(action, settings.locale)` — **display-only**. Content stays canonical English, so the gameplay replacement pipeline (`actionStringReplacement`, which matches `{dom}`/`{sub}` literally and uses the `{genital|dom}` pipe syntax) is untouched. Uses the same `placeholders` i18n namespace as the helper chips, so list and helper now agree.

> Note: this is **not** a find-and-replace on the locale content files — doing that would break runtime token replacement, import/export, and sync canonicalization.

### 2. Service-worker update prompt
The PWA had `registerType: 'prompt'` but no refresh wiring (`injectRegister: 'auto'` registered the SW with no `onNeedRefresh` handler), so a new deploy sat **waiting silently** until every tab closed — users stayed on the old bundle (this is why German didn't appear after deploy).

**Fix:** new `ReloadPrompt` component uses `useRegisterSW` to show a *"new version available — Reload"* snackbar. User-triggered reload (not auto) so an active game is never interrupted. Adds `updateAvailable`/`reload` strings in all six languages.

## Verification
- `npm run type-check` ✅
- `npx eslint` on changed files ✅ (only a pre-existing warning)
- `npm run build` ✅ — PWA `generateSW` runs; `sw.js` includes the `SKIP_WAITING` handler the Reload button posts to; single SW registration site (the hook owns it — `'auto'` suppressed its own inject)
- `npm run test:failures` ✅ — 1380 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)