### PR TITLE
fix(sentry): triage production errors — fix root causes, filter noise

### DIFF
--- a/src/services/__tests__/playerStatsService.test.ts
+++ b/src/services/__tests__/playerStatsService.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, test, expect, beforeEach } from 'vitest';
+import { fetchPlayerStats, recordDiceRoll } from '../playerStatsService';
+import db from '@/stores/store';
+
+describe('playerStatsService', () => {
+  beforeEach(async () => {
+    await db.globalPlayerStats.clear();
+  });
+
+  describe('fetchPlayerStats (read-only — safe for liveQuery)', () => {
+    test('returns a default object without writing when no row exists', async () => {
+      const stats = await fetchPlayerStats('owner-1');
+
+      expect(stats.ownerId).toBe('owner-1');
+      expect(stats.diceRollCount).toBe(0);
+      expect(stats.id).toBeUndefined();
+
+      // The read must not have created a row — this is what triggered the
+      // Dexie ReadOnlyError when called inside a liveQuery.
+      const count = await db.globalPlayerStats.count();
+      expect(count).toBe(0);
+    });
+
+    test('returns the existing row when one exists', async () => {
+      await recordDiceRoll('owner-2', 6);
+
+      const stats = await fetchPlayerStats('owner-2');
+      expect(stats.id).toBeDefined();
+      expect(stats.diceRollCount).toBe(1);
+      expect(stats.diceRollSum).toBe(6);
+    });
+  });
+
+  describe('getOrCreateStats idempotency (via recordDiceRoll)', () => {
+    test('concurrent first-time writes create exactly one row', async () => {
+      // Mirrors a multi-dice roll firing recordDiceRoll in parallel for a brand-new owner.
+      await Promise.all([
+        recordDiceRoll('owner-3', 1),
+        recordDiceRoll('owner-3', 2),
+        recordDiceRoll('owner-3', 3),
+      ]);
+
+      const rows = await db.globalPlayerStats.where('ownerId').equals('owner-3').toArray();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].diceRollCount).toBe(3);
+    });
+  });
+});

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -55,10 +55,7 @@ import { stripImageMetadata } from '@/services/imageProcessing';
 import { User as UserType } from '@/types';
 import { initializeApp } from 'firebase/app';
 import { sha256 } from 'js-sha256';
-import {
-  reportFirefoxMobileAuthError,
-  reportFirefoxMobileConnectivityIssue,
-} from '@/utils/firefoxMobileReporting';
+import { reportFirefoxMobileAuthError } from '@/utils/firefoxMobileReporting';
 
 interface FirebaseConfig {
   apiKey: string;
@@ -88,39 +85,6 @@ const missingVars = Object.entries(firebaseConfig)
 if (missingVars.length > 0) {
   console.error('Missing Firebase environment variables', missingVars);
   console.error('Please check your .env file and ensure all VITE_FIREBASE_* variables are set');
-}
-
-// Check if we can reach Firebase (potential uBlock Origin issue)
-const checkFirebaseConnectivity = async () => {
-  try {
-    // Use Firebase Auth REST API endpoint for connectivity check
-    const testUrl = `https://identitytoolkit.googleapis.com/v1/projects/${firebaseConfig.projectId}`;
-    const response = await fetch(testUrl, { method: 'GET' });
-
-    if (!response.ok) {
-      // Report non-OK status as connectivity issue
-      const statusError = new Error(`HTTP ${response.status}: ${response.statusText}`);
-      reportFirefoxMobileConnectivityIssue({
-        testUrl,
-        error: statusError,
-      });
-    }
-    // Only report success if there were previous failures
-  } catch (error) {
-    reportFirefoxMobileConnectivityIssue({
-      testUrl: `https://identitytoolkit.googleapis.com/v1/projects/${firebaseConfig.projectId}`,
-      error: error as Error,
-    });
-  }
-};
-
-// Run connectivity check for Firefox mobile users
-if (
-  navigator.userAgent.toLowerCase().includes('firefox') &&
-  (navigator.userAgent.toLowerCase().includes('mobile') ||
-    navigator.userAgent.toLowerCase().includes('tablet'))
-) {
-  checkFirebaseConnectivity();
 }
 
 const app = initializeApp(firebaseConfig);

--- a/src/services/migration/groupIdMigration.ts
+++ b/src/services/migration/groupIdMigration.ts
@@ -229,9 +229,11 @@ export async function migrateDefaultGroupIds(): Promise<{
             await updateCustomTile(tile.id!, { group_id: expectedId });
           }
 
-          // Delete the old group and create with new ID
+          // Delete the old group and write the new ID. Use put (upsert) so a concurrent
+          // tab that already wrote expectedId can't collide into a ConstraintError —
+          // expectedId is the stable deterministic id for the same logical group.
           await db.customGroups.delete(group.id);
-          await db.customGroups.add({
+          await db.customGroups.put({
             ...group,
             id: expectedId,
             updatedAt: new Date(),

--- a/src/services/playerStatsService.ts
+++ b/src/services/playerStatsService.ts
@@ -18,29 +18,39 @@ function createDefaultStats(): Omit<GlobalPlayerStats, 'id' | 'ownerId'> {
   };
 }
 
+// Atomic read-or-create so concurrent writers (e.g. multi-dice rolls) don't both
+// insert a row for the same ownerId. IndexedDB serializes overlapping-scope rw
+// transactions, so the existence re-check inside the transaction prevents duplicates.
 async function getOrCreateStats(ownerId: string): Promise<GlobalPlayerStats> {
-  const existing = await db.globalPlayerStats.where('ownerId').equals(ownerId).first();
+  return db.transaction('rw', db.globalPlayerStats, async () => {
+    const existing = await db.globalPlayerStats.where('ownerId').equals(ownerId).first();
 
-  if (existing) {
-    return { ...createDefaultStats(), ...existing };
-  }
+    if (existing) {
+      return { ...createDefaultStats(), ...existing };
+    }
 
-  const newStats = { ownerId, ...createDefaultStats() };
-  const id = await db.globalPlayerStats.add(newStats);
-  return { ...newStats, id };
+    const newStats = { ownerId, ...createDefaultStats() };
+    const id = await db.globalPlayerStats.add(newStats);
+    return { ...newStats, id };
+  });
 }
 
 export async function recordDiceRoll(ownerId: string, rollValue: number): Promise<void> {
-  const stats = await getOrCreateStats(ownerId);
+  // Wrap read-modify-write in one transaction so burst rolls (multi-dice) accumulate
+  // correctly instead of clobbering each other. getOrCreateStats' inner rw transaction
+  // joins this one (same scope), so creation stays atomic too.
+  await db.transaction('rw', db.globalPlayerStats, async () => {
+    const stats = await getOrCreateStats(ownerId);
 
-  const newDistribution = { ...stats.diceDistribution };
-  newDistribution[rollValue] = (newDistribution[rollValue] || 0) + 1;
+    const newDistribution = { ...stats.diceDistribution };
+    newDistribution[rollValue] = (newDistribution[rollValue] || 0) + 1;
 
-  await db.globalPlayerStats.update(stats.id!, {
-    diceRollCount: stats.diceRollCount + 1,
-    diceRollSum: stats.diceRollSum + rollValue,
-    diceDistribution: newDistribution,
-    lastActive: Date.now(),
+    await db.globalPlayerStats.update(stats.id!, {
+      diceRollCount: stats.diceRollCount + 1,
+      diceRollSum: stats.diceRollSum + rollValue,
+      diceDistribution: newDistribution,
+      lastActive: Date.now(),
+    });
   });
 }
 
@@ -123,6 +133,10 @@ export async function recordIntensities(ownerId: string, intensities: string[]):
   });
 }
 
+// Read-only — safe to call inside a Dexie liveQuery. Never writes; returns an
+// in-memory default (no id) when no row exists yet. Lazy creation happens only in
+// the record* writers, which run outside the liveQuery context.
 export async function fetchPlayerStats(ownerId: string): Promise<GlobalPlayerStats> {
-  return getOrCreateStats(ownerId);
+  const existing = await db.globalPlayerStats.where('ownerId').equals(ownerId).first();
+  return existing ? { ...createDefaultStats(), ...existing } : { ownerId, ...createDefaultStats() };
 }

--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -25,6 +25,11 @@ const IGNORED_ERROR_PATTERNS = [
   /permission denied/i,
   /user denied permission/i,
   /not allowed by the user agent/i,
+  // User navigated away / fetch aborted mid-flight — not actionable
+  /AbortError/i,
+  /the user aborted a request/i,
+  // Rejected promise with no value — nothing to act on (known noisy pattern)
+  /Non-Error promise rejection captured/i,
 ];
 
 /**

--- a/src/stores/customGroups.ts
+++ b/src/stores/customGroups.ts
@@ -264,7 +264,9 @@ export const importCustomGroups = async (
       return fullGroup;
     });
 
-    return await customGroups.bulkAdd(groupsWithAllFields);
+    // bulkPut (upsert) keeps re-imports idempotent. Ids are globally-unique nanoids,
+    // so a matching id is the same logical group — overwriting is correct, not collision.
+    return await customGroups.bulkPut(groupsWithAllFields);
   } catch (error) {
     console.error('Error in importCustomGroups:', error);
     return undefined;

--- a/src/stores/customTiles.ts
+++ b/src/stores/customTiles.ts
@@ -45,7 +45,10 @@ customTiles.hook('updating', function (this: any, modifications: any) {
 export const importCustomTiles = async (
   record: Partial<CustomTile>[]
 ): Promise<number | undefined> => {
-  const recordData = record.map((tile) => ({ ...tile, isEnabled: 1 }));
+  // Strip any incoming id: customTiles uses a local ++id autoincrement, so a foreign
+  // id (from another device's import) would collide arbitrarily. Let Dexie assign fresh
+  // local ids — same pattern the sync engine uses (removeId + add).
+  const recordData = record.map(({ id: _id, ...tile }) => ({ ...tile, isEnabled: 1 }));
   return await customTiles.bulkAdd(recordData as CustomTile[]);
 };
 

--- a/src/utils/firefoxMobileReporting.ts
+++ b/src/utils/firefoxMobileReporting.ts
@@ -115,37 +115,3 @@ export function reportFirefoxMobileAuthError(
     category: 'firefox_mobile_auth',
   });
 }
-
-export function reportFirefoxMobileConnectivityIssue(details: {
-  testUrl: string;
-  error: Error;
-}): void {
-  if (!isFirefoxMobile()) {
-    return;
-  }
-
-  const context: FirefoxMobileContext = {
-    ...gatherSystemContext(),
-    authentication: {
-      step: 'connectivity_check',
-    },
-    error: {
-      message: details.error.message,
-      stack: details.error.stack,
-    },
-  } as FirefoxMobileContext;
-
-  Sentry.withScope((scope) => {
-    scope.setTag('firefox_mobile_connectivity_error', true);
-    scope.setLevel('warning');
-    scope.setContext('connectivity_test', {
-      testUrl: details.testUrl,
-      ...context,
-    } as any);
-
-    Sentry.captureMessage(
-      `Firefox Mobile Connectivity Issue: Failed to reach ${details.testUrl}. This may indicate uBlock Origin or another adblocker is blocking Firebase.`,
-      'warning'
-    );
-  });
-}

--- a/src/views/Room/RollButton/index.tsx
+++ b/src/views/Room/RollButton/index.tsx
@@ -95,13 +95,15 @@ const RollButton = forwardRef<RollButtonHandle, RollButtonProps>(function RollBu
   const triggerDiceAnimation = useCallback((): void => {
     const roll = calculateDiceRoll(rollCount, diceSide);
 
-    // Record dice roll statistics
+    // Record dice roll statistics. Serialize the writes so the lazy row-creation in
+    // getOrCreateStats can't race itself and produce duplicate stat rows on first roll.
     const ownerId = user?.uid || 'anonymous';
-    if (Array.isArray(roll.values)) {
-      roll.values.forEach((value) => recordDiceRoll(ownerId, value));
-    } else {
-      recordDiceRoll(ownerId, roll.values);
-    }
+    const rolledValues = Array.isArray(roll.values) ? roll.values : [roll.values];
+    void (async () => {
+      for (const value of rolledValues) {
+        await recordDiceRoll(ownerId, value);
+      }
+    })();
 
     // If dice animation is disabled, immediately set the roll value
     if (settings.showDiceAnimation === false) {


### PR DESCRIPTION
Triages six production Sentry issues: fixes three real bugs at the root, filters two non-actionable patterns, and stops one intentional diagnostic that's no longer needed.

## Real bugs fixed

**ReadOnlyError: Readwrite transaction in liveQuery context**
`usePlayerStats` runs a Dexie `useLiveQuery` over `fetchPlayerStats`, which lazily wrote a row via `.add()` — illegal inside a read-only liveQuery. `fetchPlayerStats` is now read-only: it returns an in-memory default (no `id`) when no row exists. Lazy creation stays in the `record*` writers, which run outside liveQuery.

**Duplicate / lost stat updates (same code path)**
`RollButton` fired parallel un-awaited `recordDiceRoll` on multi-dice rolls, racing first-time row creation (duplicate rows) and the count read-modify-write (lost updates). Now: `getOrCreateStats` is atomic, `recordDiceRoll` wraps its read-modify-write in one transaction, and `RollButton` serializes the writes. Burst rolls create exactly one row and accumulate correctly.

**ConstraintError: Key already exists in the object store**
Hardens every explicit-primary-key write path:
- `migrateDefaultGroupIds`: `add` → `put` (closes a multi-tab race on the deterministic group id). *Leading candidate for the unhandled event.*
- `importCustomGroups`: `bulkAdd` → `bulkPut` (nanoid keys are stable — upsert is the intended idempotent behavior).
- `importCustomTiles`: strips foreign autoincrement `id` before `bulkAdd` (matches the sync engine's `removeId` pattern; avoids clobbering unrelated local tiles — `bulkPut` would be wrong here).

## Noise filtered (`sentry.ts` `ignoreErrors`)
- `AbortError` / "the user aborted a request" — navigation, not actionable.
- "Non-Error promise rejection captured" — value-less rejections, nothing to act on.

## Diagnostic removed
Firefox-mobile connectivity reporting (intentional adblock probe) is removed — the behavior is confirmed and the warning was flooding Sentry. `reportFirefoxMobileAuthError` and the rest of `firefoxMobileReporting.ts` are kept.

## Tests
Adds `playerStatsService.test.ts`: read-only `fetchPlayerStats` writes nothing when no row exists; concurrent first-time rolls create exactly one row and accumulate.

## Verification
- `npm run type-check` ✓ · `eslint` ✓ (only a pre-existing unrelated warning) · `npm run test:failures` ✓ (1402 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)