### PR TITLE
feat(phase-0): lifecycle analytics rework + board default 60 + flexible public board size

### DIFF
--- a/docs/plans/growth-flywheel-2026-07.md
+++ b/docs/plans/growth-flywheel-2026-07.md
@@ -1,0 +1,88 @@
+# Growth Plan: Activation Fast Lane + Content-Pack Flywheel
+
+_Agreed 2026-07-03 after grilling session + UX specialist review. Status: planned, not started._
+
+## Strategy
+
+**Spine:** content-pack creation flywheel is the growth engine (NSFW app — paid ads and app stores mostly closed; organic growth comes from content + shareability). Activation funnel is the prerequisite: nobody creates packs before they play successfully. Pure acquisition work deferred.
+
+**Context:** ~2K active users/period, 69% mobile (tablet negligible). Most users play Solo despite party (jackbox-style) framing. Known complaint: games too short. Pack directory shipped (#1103) but holds only 2 packs — creation workflow is scattered across accordion sections and requires self-assembly.
+
+## Phase 0 — Measure + trivial wins
+
+### Analytics rework (ships first — baseline for everything after)
+
+Current `custom_group_action` GA4 event is **seeding noise**: it fires from `customGroups.ts` store CRUD when default groups are seeded per user/locale at migration. It is not preference data (ballBusting ≈ kissing because every user's DB seeds both).
+
+New event set (GA4 only, existing privacy rules — no names, room codes, or content text):
+
+- `wizard_screen_view` / `wizard_completed` / `wizard_abandoned` — per screen, per topology
+- `game_started` (topology, group count, board size) + `groups_selected` — actual picks at game start
+- `action_rolled` (count), `game_finished` (finish tile reached), `game_abandoned` (roll count + minutes)
+- Flywheel: `pack_directory_viewed`, `pack_previewed`, `pack_imported`, `pack_published`, `pack_creation_started` / `_completed`
+- `feature_usage` on major features (cast, video call, TTS, backgrounds, custom dialog)
+- Kill/rename seeding-noise event; keep CRUD tracking for user-initiated creates only
+
+Naming: `noun_verb`, shared param dictionary. Goal: answer "are they trying the game? rolling? reaching the end? what's used/unused?"
+
+### Board default 60
+
+Default board size 40 → 60 tiles (addresses too-short complaint, zero new UI). No size step in wizard.
+
+## Phase 1 — Activation: wizard fast lane
+
+Target: Solo path = topology tap → identity → actions → play.
+
+- **Topology screen** (already three cards): move Solo card's private-room checkbox to More options; all three cards auto-advance on tap.
+- **Verify first:** does role affect solo action text? Current solo flow deliberately omits role (`showRole = isOnline && !soloPlay` in GameModeStep). Determines identity-screen contents (anatomy ± role).
+- **Actions screen rebuild** (`ActionsStep`):
+  - "Starters" preset row (horizontal cards) replaces the Quick Start ⟷ Customize mutually-exclusive accordion — presets select groups + intensities, chips reflect it.
+  - **Spice dial** = _non-destructive default-setter_: preselects intensity band per group by ladder percentile, but only for groups the user never hand-edited (edited groups show a "custom" dot, never overwritten). App vocabulary labels (Mild/Spicy/Filthy), not numbers. **Consent hazard note:** silent per-group preselection in an NSFW app must never surprise — dial sets defaults, bottom sheet is the editor of record.
+  - Group chips by category (actions / consumptions), selected chips show level badge ("2/4", "1,3").
+  - Badge tap → **bottom sheet** (`SwipeableDrawer anchor="bottom"`, fullscreen Dialog below `sm`) with that group's real level labels, checkbox per level (non-contiguous allowed), per-level tile counts, pinned confirm button. Not a popover — clips/misplaces on mobile.
+  - Consumptions keep their own section + combine/standalone (`isAppend`) toggle — not folded into dial.
+  - **Cap stays 4 actions + 2 consumptions** (locked decision): slot counter ("2 of 4 picked"), chips disabled at cap. Advanced settings remain the escape hatch for complex boards.
+  - Preserve: migration-aware loading, `BrokenActionsState`, `hasValidSelections` gating, `isNaked`/`soloPlay` content-type gating.
+- Advanced `GameSettings` unchanged as deep editor; both surfaces read/write identical `selectedActions` shape; chip screen re-reads on return.
+
+## Phase 2 — Discovery (flywheel demand side)
+
+- **Seed packs:** owner authors 4–6 packs (solo / couples / party group / warm-up spread) under app-brand author name. Directory surfacing gated on seeds being in.
+- **Directory surfacing:** "Explore community packs" card at end of actions-screen group list + slim banner when user has zero custom content. Directory renders as **inline wizard sub-view** (pane swap + back button — no stacked dialog; `PackImportDialog` remains the only overlay). After import: reload `actionsList` and auto-select imported groups (wizard currently only reloads on migration toggle — needs `onImported` wiring).
+- **Incentive v1:** import counter on pack cards (Firestore increment on import) + author display name. **No author profiles** — anonymity is a feature in NSFW context. No ratings/comments v1 (moderation surface stays small; report flow #1104 exists).
+- Landing-page pack teaser = later phase (needs full shelf).
+
+## Phase 3 — Creation (flywheel supply side)
+
+**Guided "Create a Pack" flow** as a **route-level fullscreen view** (like ManageGameBoards) — NOT inside CustomTileDialog (modal stack already 3 deep with scroll/popper DOM hacks). `MobileStepper`/top Stepper, one step per screen, sticky bottom action bar.
+
+1. **Start point:** blank · copy own groups · duplicate an imported pack · **duplicate a default group** (new capability — copies default tiles into a custom group, canonical-English placeholders intact; biggest hidden scope item).
+2. **Pack identity:** name (100), description (1000), tags (≤20).
+3. **Content:** create/edit groups + tiles inline — **reuse existing components/hooks** (`useCustomTileLifecycle`, `submitCustomTileCore`, `validationService`, group editor). Do not clone editors.
+4. **Publish:** preview → visibility (public/private; anonymous users forced private) → share link.
+
+Draft persists as local custom content (pack = selection over it). **Republish path required:** "Update pack" entry from my-packs for version bump — create-only flow strands authors.
+
+**Replace, don't layer (deletions on ship):**
+
+- Delete publish form from Packs accordion → becomes "Create a pack →" button + import-by-code field.
+- P3 step 3 and AddCustomTile's "Manage Groups" open the same editor surface; retire CustomGroupDialog-as-stacked-modal.
+- Import/Export JSON relabeled "Backup" (packs = sharing; JSON = backup).
+- Longer term: retire accordion-as-navigation in CustomTileDialog on mobile (list→detail or tabs).
+
+## Acceptance checklist — primitives that must survive every phase
+
+- Non-contiguous intensity level selection with real per-group labels
+- Consumption combine/standalone toggle
+- Disabled-default tile tombstones (curation + sync semantics)
+- Tile-level tags; placeholder help chips; live tile preview
+- JSON import/export, all 4 scopes (rebranded Backup)
+- Pack visibility control + anonymous-forced-private
+- Report-abuse affordance in pack preview
+
+## Backlog (explicitly out of scope)
+
+- Lift the 4+2 group cap (needs board-builder dilution work)
+- "Keep playing" end-of-game CTA / board size selector UI
+- Landing-page pack teaser / SEO pack pages
+- Ratings, comments, author profiles

--- a/src/components/MessageList/Message/index.tsx
+++ b/src/components/MessageList/Message/index.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 import { Box, Button, Chip, IconButton, Popover, Typography } from '@mui/material';
 import HomeIcon from '@mui/icons-material/Home';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -49,7 +50,7 @@ export default function Message({
   message,
   isOwnMessage,
   isTransparent,
-  currentGameBoardSize = 40,
+  currentGameBoardSize = DEFAULT_TILE_COUNT,
   room,
 }: MessageProps): JSX.Element {
   const { t, i18n } = useTranslation();

--- a/src/components/MessageList/index.tsx
+++ b/src/components/MessageList/index.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 import Fab from '@mui/material/Fab';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -27,7 +28,7 @@ interface MessageListProps {
 export default function MessageList({
   room,
   isTransparent,
-  currentGameBoardSize = 40,
+  currentGameBoardSize = DEFAULT_TILE_COUNT,
 }: MessageListProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
   const { user } = useAuth();

--- a/src/constants/boardConstants.ts
+++ b/src/constants/boardConstants.ts
@@ -1,0 +1,9 @@
+/**
+ * Constants for game board sizing
+ */
+
+/**
+ * Default number of tiles on a game board when the user hasn't chosen a size.
+ * Public rooms always use this size so every player's board lines up.
+ */
+export const DEFAULT_TILE_COUNT = 60;

--- a/src/hooks/__tests__/useGameBoard.test.ts
+++ b/src/hooks/__tests__/useGameBoard.test.ts
@@ -165,7 +165,7 @@ describe('useGameBoard', () => {
       expect(gameResult.settingsBoardUpdated).toBe(true);
     });
 
-    it('should use 40 tiles for public rooms regardless of roomTileCount', async () => {
+    it('should respect the user roomTileCount in public rooms', async () => {
       vi.mocked(isPublicRoom).mockReturnValue(true);
 
       const { result } = renderHook(() => useGameBoard());
@@ -173,7 +173,18 @@ describe('useGameBoard', () => {
       const settingsWithLargeTileCount = { ...mockSettings, roomTileCount: 100 };
       await result.current(settingsWithLargeTileCount);
 
-      expect(buildGameBoard).toHaveBeenCalledWith(expect.any(Object), 'en', 'online', 40);
+      expect(buildGameBoard).toHaveBeenCalledWith(expect.any(Object), 'en', 'online', 100);
+    });
+
+    it('should fall back to the default tile count when roomTileCount is unset', async () => {
+      vi.mocked(isPublicRoom).mockReturnValue(true);
+
+      const { result } = renderHook(() => useGameBoard());
+
+      const settingsWithoutTileCount = { ...mockSettings, roomTileCount: undefined };
+      await result.current(settingsWithoutTileCount);
+
+      expect(buildGameBoard).toHaveBeenCalledWith(expect.any(Object), 'en', 'online', 60);
     });
   });
 

--- a/src/hooks/useBoardContentWarnings.ts
+++ b/src/hooks/useBoardContentWarnings.ts
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { getContentGameMode, isPublicRoom } from '@/helpers/strings';
 import buildGameBoard from '@/services/buildGame';
 import { Settings } from '@/types/Settings';
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 
 export interface BoardContentWarnings {
   /** Selected groups that have no available tiles for the current locale/mode. */
@@ -39,7 +40,7 @@ export default function useBoardContentWarnings(formData: Settings): BoardConten
       const isPublic = isPublicRoom(room || '');
       const finalGameMode = getContentGameMode(isPublic ? 'online' : gameMode);
       const locale = i18n.resolvedLanguage || 'en';
-      const tileCount = isPublic ? 40 : roomTileCount || 40;
+      const tileCount = roomTileCount || DEFAULT_TILE_COUNT;
 
       try {
         const { metadata } = await buildGameBoard(formData, locale, finalGameMode, tileCount);

--- a/src/hooks/useGameBoard.ts
+++ b/src/hooks/useGameBoard.ts
@@ -7,6 +7,7 @@ import { getActiveBoard, upsertBoard } from '@/stores/gameBoard';
 import { useCallback } from 'react';
 import { Settings } from '@/types/Settings';
 import { DBGameBoard, GameBoardResult } from '@/types/gameBoard';
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 
 /**
  * Builds a game board based on the settings provided.
@@ -32,7 +33,7 @@ export default function useGameBoard(): (data: Settings) => Promise<GameBoardRes
               },
             };
       let { gameMode, boardUpdated: settingsBoardUpdated } = formData;
-      const { roomTileCount = 40, finishRange, room } = formData;
+      const { roomTileCount = DEFAULT_TILE_COUNT, finishRange, room } = formData;
       const isPublic = isPublicRoom(room || '');
 
       if (!data || !finishRange) {
@@ -50,7 +51,7 @@ export default function useGameBoard(): (data: Settings) => Promise<GameBoardRes
 
       const finalGameMode = getContentGameMode(gameMode);
       const locale = i18n.resolvedLanguage || 'en';
-      const tileCount = isPublic ? 40 : roomTileCount || 40;
+      const tileCount = roomTileCount || DEFAULT_TILE_COUNT;
 
       // Use the new streamlined buildGameBoard function
       const boardResult = await buildGameBoard(formData, locale, finalGameMode, tileCount);

--- a/src/hooks/useSendSettings.ts
+++ b/src/hooks/useSendSettings.ts
@@ -20,7 +20,9 @@ function isCompatibleBoard(
   latestRoomMessage?: RoomMessage,
   roomTileCount?: number
 ): boolean {
-  if (!isPrivateRoom && boardSize === 40) return true;
+  // Public rooms allow any board size — only private rooms need boards to
+  // line up with the room's shared tile count.
+  if (!isPrivateRoom) return true;
 
   if (!latestRoomMessage) return false;
 

--- a/src/hooks/useUrlImport.ts
+++ b/src/hooks/useUrlImport.ts
@@ -83,6 +83,10 @@ export default function useUrlImport(
         finalSettings.gameMode = 'online';
       }
 
+      // Adopt the imported board's size so settings and board stay in sync
+      // even when the author's saved settings disagree with the actual tiles.
+      finalSettings.roomTileCount = importedGameBoard.length;
+
       setSettings(finalSettings);
 
       if (alert !== t('updated')) {

--- a/src/hooks/useWizardAnalytics.ts
+++ b/src/hooks/useWizardAnalytics.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { analytics } from '@/services/analytics';
 import { getWizardStepName } from '@/views/GameSettingsWizard/stepConfig';
 
@@ -8,38 +8,55 @@ interface UseWizardAnalyticsProps {
 }
 
 interface WizardAnalytics {
-  trackStepNavigation: (currentStep: number, targetStep?: number) => void;
+  trackScreenView: (step: number) => void;
+}
+
+// Module-level so FinishStep (a separate hook instance) can mark completion
+// before the wizard unmounts and the abandonment check runs.
+let wizardCompleted = false;
+
+export function markWizardCompleted(): void {
+  wizardCompleted = true;
 }
 
 /**
- * Custom hook for tracking wizard funnel analytics
- * Handles path-specific funnel tracking without cluttering components
+ * Wizard funnel analytics: one screen-view per step entered, a completion
+ * event when settings are submitted, and an abandonment event (with the last
+ * screen seen) if the wizard unmounts without completing.
  */
 export function useWizardAnalytics({
   gameMode = 'online',
   isPublicRoom = false,
 }: UseWizardAnalyticsProps): WizardAnalytics {
-  const getFunnelName = useCallback(() => {
-    const roomType = isPublicRoom ? 'public' : 'private';
-    return `${gameMode}_${roomType}_setup`;
-  }, [gameMode, isPublicRoom]);
+  const roomType = isPublicRoom ? 'public' : 'private';
+  const lastScreenRef = useRef<string | null>(null);
 
-  const getStepName = useCallback((stepNumber: number): string => {
-    return getWizardStepName(stepNumber);
-  }, []);
+  // Keep current values readable from the unmount cleanup without re-running it
+  const contextRef = useRef({ gameMode, roomType });
+  contextRef.current = { gameMode, roomType };
 
-  const trackStepNavigation = useCallback(
-    (currentStep: number, targetStep?: number) => {
-      const funnelName = getFunnelName();
-      const stepToTrack = targetStep ?? currentStep;
-      const stepName = getStepName(stepToTrack);
-
-      analytics.trackFunnelStep(funnelName, stepName, stepToTrack, true);
+  const trackScreenView = useCallback(
+    (step: number) => {
+      const screenName = getWizardStepName(step);
+      if (screenName === lastScreenRef.current) return;
+      lastScreenRef.current = screenName;
+      analytics.trackWizardScreenView(screenName, gameMode, roomType);
     },
-    [getFunnelName, getStepName]
+    [gameMode, roomType]
   );
 
+  useEffect(() => {
+    wizardCompleted = false;
+    return () => {
+      if (!wizardCompleted && lastScreenRef.current) {
+        const { gameMode: topology, roomType: room } = contextRef.current;
+        analytics.trackWizardAbandoned(lastScreenRef.current, topology, room);
+      }
+      wizardCompleted = false;
+    };
+  }, []);
+
   return {
-    trackStepNavigation,
+    trackScreenView,
   };
 }

--- a/src/services/__tests__/analytics.test.ts
+++ b/src/services/__tests__/analytics.test.ts
@@ -174,6 +174,151 @@ describe('Analytics Service', () => {
     });
   });
 
+  describe('Wizard Funnel Tracking', () => {
+    it('should track wizard screen views with topology context', () => {
+      analytics.trackWizardScreenView('actions', 'solo', 'public');
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'wizard_screen_view',
+        expect.objectContaining({
+          event_category: 'wizard_funnel',
+          event_label: 'actions',
+          screen_name: 'actions',
+          topology: 'solo',
+          room_type: 'public',
+        })
+      );
+    });
+
+    it('should track wizard completion', () => {
+      analytics.trackWizardCompleted('online', 'private', 4);
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'wizard_completed',
+        expect.objectContaining({
+          event_category: 'wizard_funnel',
+          topology: 'online',
+          room_type: 'private',
+          value: 4,
+        })
+      );
+    });
+
+    it('should track wizard abandonment with the last screen seen', () => {
+      analytics.trackWizardAbandoned('room', 'online', 'private');
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'wizard_abandoned',
+        expect.objectContaining({
+          event_category: 'wizard_funnel',
+          event_label: 'room',
+          screen_name: 'room',
+          topology: 'online',
+        })
+      );
+    });
+  });
+
+  describe('Game Lifecycle Tracking', () => {
+    it('should track game start with board context', () => {
+      analytics.trackGameStarted({
+        topology: 'solo',
+        room_type: 'public',
+        group_count: 3,
+        board_size: 60,
+      });
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'game_started',
+        expect.objectContaining({
+          event_category: 'gameplay',
+          topology: 'solo',
+          room_type: 'public',
+          value: 3,
+          board_size: 60,
+        })
+      );
+    });
+
+    it('should track selected groups individually at game start', () => {
+      analytics.trackGroupSelected('ballBusting', [1, 3], 'sex');
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'group_selected',
+        expect.objectContaining({
+          event_category: 'gameplay',
+          event_label: 'ballBusting',
+          levels: '1,3',
+          group_type: 'sex',
+        })
+      );
+    });
+
+    it('should track rolls with a running count', () => {
+      analytics.trackActionRolled(5);
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'action_rolled',
+        expect.objectContaining({
+          event_category: 'gameplay',
+          value: 5,
+        })
+      );
+    });
+
+    it('should track a finished game with roll count and duration', () => {
+      analytics.trackGameFinished(12, 600000, 'online', 2);
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'game_finished',
+        expect.objectContaining({
+          event_category: 'gameplay',
+          roll_count: 12,
+          value: 600000,
+          game_mode: 'online',
+          player_count: 2,
+        })
+      );
+    });
+
+    it('should track an abandoned game with roll count and duration', () => {
+      analytics.trackGameAbandoned(2, 90000, 'solo', 1);
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'game_abandoned',
+        expect.objectContaining({
+          event_category: 'gameplay',
+          roll_count: 2,
+          value: 90000,
+        })
+      );
+    });
+  });
+
+  describe('Content Pack Tracking', () => {
+    it('should track pack lifecycle events by name', () => {
+      analytics.trackPackEvent('pack_imported', { group_count: 2, tile_count: 40 });
+
+      expect(mockGtag).toHaveBeenCalledWith(
+        'event',
+        'pack_imported',
+        expect.objectContaining({
+          event_category: 'content_packs',
+          group_count: 2,
+          tile_count: 40,
+        })
+      );
+    });
+  });
+
   describe('Feature Usage Tracking', () => {
     it('should track feature usage with proper categorization', () => {
       analytics.trackFeatureUsage({

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -288,14 +288,109 @@ class AnalyticsService {
     });
   }
 
-  // Track feature adoption funnel
-  trackFunnelStep(funnelName: string, step: string, stepNumber: number, success: boolean) {
-    this.trackEvent('funnel_step', {
-      event_category: 'conversion',
-      event_label: funnelName,
-      value: stepNumber,
-      custom_parameter_1: step,
-      custom_parameter_2: success.toString(),
+  // --- Wizard funnel (lifecycle analytics) ---
+
+  trackWizardScreenView(screenName: string, topology: string, roomType: string) {
+    this.trackEvent('wizard_screen_view', {
+      event_category: 'wizard_funnel',
+      event_label: screenName,
+      screen_name: screenName,
+      topology,
+      room_type: roomType,
+    });
+  }
+
+  trackWizardCompleted(topology: string, roomType: string, groupCount: number) {
+    this.trackEvent('wizard_completed', {
+      event_category: 'wizard_funnel',
+      event_label: topology,
+      topology,
+      room_type: roomType,
+      value: groupCount,
+    });
+  }
+
+  trackWizardAbandoned(lastScreenName: string, topology: string, roomType: string) {
+    this.trackEvent('wizard_abandoned', {
+      event_category: 'wizard_funnel',
+      event_label: lastScreenName,
+      screen_name: lastScreenName,
+      topology,
+      room_type: roomType,
+    });
+  }
+
+  // --- Game lifecycle (are they playing? rolling? reaching the end?) ---
+
+  trackGameStarted(params: {
+    topology: string;
+    room_type: string;
+    group_count: number;
+    board_size: number;
+  }) {
+    this.trackEvent('game_started', {
+      event_category: 'gameplay',
+      event_label: params.topology,
+      topology: params.topology,
+      room_type: params.room_type,
+      value: params.group_count,
+      board_size: params.board_size,
+    });
+  }
+
+  trackGroupSelected(groupName: string, levels: number[], groupType: string) {
+    this.trackEvent('group_selected', {
+      event_category: 'gameplay',
+      event_label: groupName,
+      levels: levels.join(','),
+      group_type: groupType,
+    });
+  }
+
+  trackActionRolled(rollCount: number) {
+    this.trackEvent('action_rolled', {
+      event_category: 'gameplay',
+      value: rollCount,
+    });
+  }
+
+  trackGameFinished(rollCount: number, durationMs: number, gameMode: string, playerCount: number) {
+    this.trackEvent('game_finished', {
+      event_category: 'gameplay',
+      event_label: gameMode,
+      roll_count: rollCount,
+      value: durationMs,
+      game_mode: gameMode,
+      player_count: playerCount,
+    });
+  }
+
+  trackGameAbandoned(rollCount: number, durationMs: number, gameMode: string, playerCount: number) {
+    this.trackEvent('game_abandoned', {
+      event_category: 'gameplay',
+      event_label: gameMode,
+      roll_count: rollCount,
+      value: durationMs,
+      game_mode: gameMode,
+      player_count: playerCount,
+    });
+  }
+
+  // --- Content pack lifecycle ---
+
+  trackPackEvent(
+    eventName:
+      | 'pack_directory_viewed'
+      | 'pack_previewed'
+      | 'pack_imported'
+      | 'pack_published'
+      | 'pack_creation_started'
+      | 'pack_creation_completed',
+    params: BaseAnalyticsEvent & Record<string, string | number | undefined> = {}
+  ) {
+    this.trackEvent(eventName, {
+      event_category: 'content_packs',
+      ...params,
     });
   }
 

--- a/src/services/buildGame.ts
+++ b/src/services/buildGame.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 import { CustomGroupPull } from '@/types/customGroups';
 import { CustomTilePull } from '@/types/customTiles';
 import { Settings } from '@/types/Settings';
@@ -541,7 +542,7 @@ export default async function buildGameBoard(
   settings: Settings,
   locale: string,
   gameMode: string,
-  tileCount = 40,
+  tileCount = DEFAULT_TILE_COUNT,
   deps: { dataSource?: BoardDataSource; translate?: (key: string) => string } = {}
 ): Promise<BoardBuildResult> {
   const dataSource = deps.dataSource ?? dexieDataSource;

--- a/src/services/contentPacks.ts
+++ b/src/services/contentPacks.ts
@@ -28,6 +28,7 @@ import { getAuth } from 'firebase/auth';
 import { sha256 } from 'js-sha256';
 import { db } from './firebase';
 import { exportAllData, importData, EXPORT_FORMAT_VERSION } from './importExport';
+import { analytics } from './analytics';
 import { getCustomGroups } from '@/stores/customGroups';
 import { getTilesByGroupIds } from '@/stores/customTiles';
 import type { ExportData, ExportOptions, ImportResult } from '@/types/importExport';
@@ -147,6 +148,15 @@ export async function publishPack(
     createdAt: now,
     updatedAt: now,
   });
+
+  const summary = summarizeContents(contents);
+  analytics.trackPackEvent('pack_published', {
+    visibility: meta.visibility,
+    group_count: summary.groupCount,
+    tile_count: summary.tileCount,
+    pack_version: 1,
+  });
+
   return ref.id;
 }
 
@@ -171,6 +181,14 @@ export async function republishPack(
     ...summarizeContents(contents),
     updatedAt: Date.now(),
     authorName: getAuth().currentUser?.displayName || existing.authorName,
+  });
+
+  const summary = summarizeContents(contents);
+  analytics.trackPackEvent('pack_published', {
+    visibility: meta.visibility,
+    group_count: summary.groupCount,
+    tile_count: summary.tileCount,
+    pack_version: existing.packVersion + 1,
   });
 }
 
@@ -277,6 +295,12 @@ export async function importPack(pack: ContentPackDoc): Promise<ImportResult> {
       () => {}
     );
   }
+
+  analytics.trackPackEvent('pack_imported', {
+    group_count: pack.groupCount,
+    tile_count: pack.tileCount,
+    pack_version: pack.packVersion,
+  });
 
   return result;
 }

--- a/src/stores/customGroups.ts
+++ b/src/stores/customGroups.ts
@@ -146,8 +146,11 @@ export const addCustomGroup = async (group: CustomGroupBase): Promise<string | u
 
         const id = await customGroups.add(groupWithTimestamp);
 
-        // Track custom group creation (guard to avoid retrying DB writes if analytics fails)
-        analyticsTracking.trackCustomGroupAction('create', group, group.isDefault ?? false);
+        // Only user-authored groups are tracked — default groups are seeded per
+        // user/locale by migration and would drown real signal in GA4.
+        if (!(group.isDefault ?? false)) {
+          analyticsTracking.trackCustomGroupAction('create', group, false);
+        }
 
         return id;
       },
@@ -178,10 +181,13 @@ export const updateCustomGroup = async (
     const group = await customGroups.get(id);
     const result = await customGroups.update(id, updates);
 
-    // Track custom group modification
+    // Track user-authored group modifications only (default groups get
+    // touched by migrations, which isn't user signal)
     if (result > 0 && group) {
       const isDefault = (updates as Partial<CustomGroupBase>).isDefault ?? group.isDefault;
-      analyticsTracking.trackCustomGroupAction('modify', { ...group, ...updates }, isDefault);
+      if (!isDefault) {
+        analyticsTracking.trackCustomGroupAction('modify', { ...group, ...updates }, false);
+      }
     }
 
     return result;
@@ -223,8 +229,10 @@ export const deleteCustomGroup = async (
         const deletedTiles = await deleteCustomTilesByGroupId(id, group.locale, group.gameMode);
         await customGroups.delete(id);
 
-        // Track custom group deletion (best-effort)
-        analyticsTracking.trackCustomGroupAction('delete', group, group.isDefault);
+        // Track custom group deletion (best-effort; user-authored only)
+        if (!group.isDefault) {
+          analyticsTracking.trackCustomGroupAction('delete', group, false);
+        }
 
         return { success: true, tilesDeleted: deletedTiles };
       }
@@ -233,8 +241,10 @@ export const deleteCustomGroup = async (
     // Safe to delete - no tiles or force option used
     await customGroups.delete(id);
 
-    // Track custom group deletion (best-effort)
-    analyticsTracking.trackCustomGroupAction('delete', group, group.isDefault);
+    // Track custom group deletion (best-effort; user-authored only)
+    if (!group.isDefault) {
+      analyticsTracking.trackCustomGroupAction('delete', group, false);
+    }
 
     return { success: true };
   } catch (error) {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -3,12 +3,14 @@ import { Settings } from '@/types/Settings';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { analyticsTracking } from '@/services/analyticsTracking';
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 
 const defaultSettings: Settings = {
   locale: 'en',
   gameMode: 'solo',
   boardUpdated: false,
   room: 'PUBLIC',
+  roomTileCount: DEFAULT_TILE_COUNT,
   background: 'color',
   roomBackground: '',
   selectedActions: {},

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -19,6 +19,8 @@ export interface BaseAnalyticsEvent {
   custom_parameter_3?: string;
   session_id?: string;
   timestamp?: number;
+  // GA4 accepts arbitrary params; keep them primitive so reports stay queryable
+  [key: string]: string | number | boolean | undefined;
 }
 
 // Specific analytics event types using domain types

--- a/src/views/CustomTileDialog/PackDirectory/index.tsx
+++ b/src/views/CustomTileDialog/PackDirectory/index.tsx
@@ -18,6 +18,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import type { QueryDocumentSnapshot } from 'firebase/firestore';
 import PackImportDialog from '../Packs/PackImportDialog';
 import { listPublicPacks } from '@/services/contentPacks';
+import { analytics } from '@/services/analytics';
 import { getImportedPackIds } from '@/stores/customGroups';
 import { useGameSettings } from '@/stores/settingsStore';
 import { GAME_MODES } from '@/services/migration/constants';
@@ -68,6 +69,11 @@ export default function PackDirectory({
     },
     [gameMode, locale, cursor]
   );
+
+  // One directory-view event per mount (not per filter change)
+  useEffect(() => {
+    analytics.trackPackEvent('pack_directory_viewed');
+  }, []);
 
   // Reset and reload whenever the gameMode/locale filter changes.
   useEffect(() => {

--- a/src/views/CustomTileDialog/Packs/PackImportDialog.tsx
+++ b/src/views/CustomTileDialog/Packs/PackImportDialog.tsx
@@ -13,9 +13,10 @@ import {
   Typography,
 } from '@mui/material';
 import { Close } from '@mui/icons-material';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { importPack, parsePack, reportPack } from '@/services/contentPacks';
+import { analytics } from '@/services/analytics';
 import type { ContentPackDoc } from '@/types/contentPacks';
 import type { ExportTile } from '@/types/importExport';
 
@@ -80,6 +81,16 @@ export default function PackImportDialog({
       })),
     ];
   }, [groups, declaredExtensions, tiles, pack.locale, pack.gameMode]);
+
+  // One preview event each time the dialog opens for a pack
+  useEffect(() => {
+    if (open) {
+      analytics.trackPackEvent('pack_previewed', {
+        group_count: pack.groupCount,
+        tile_count: pack.tileCount,
+      });
+    }
+  }, [open, pack.groupCount, pack.tileCount]);
 
   // Bucket tiles under their group for the per-group preview sections.
   const tilesByGroup = useMemo(() => {

--- a/src/views/GameSettings/RoomSettings/GameSpeed/index.tsx
+++ b/src/views/GameSettings/RoomSettings/GameSpeed/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import { Trans, useTranslation } from 'react-i18next';
 import { Settings } from '@/types/Settings';
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 
 interface GameSpeedProps {
   formData: Settings;
@@ -73,7 +74,7 @@ export default function GameSpeed({ formData, setFormData }: GameSpeedProps): JS
           <Select
             labelId="tile-count-label"
             id="tile-count-select"
-            value={String(formData?.roomTileCount || 40)}
+            value={String(formData?.roomTileCount || DEFAULT_TILE_COUNT)}
             label={t('roomTileCount')}
             onChange={(event: SelectChangeEvent) =>
               setFormData({

--- a/src/views/GameSettingsWizard/FinishStep/index.tsx
+++ b/src/views/GameSettingsWizard/FinishStep/index.tsx
@@ -18,6 +18,9 @@ import { Settings } from '@/types/Settings';
 import { arraysEqual } from '@/helpers/arrays';
 import useSubmitGameSettings from '@/hooks/useSubmitGameSettings';
 import { useParams } from 'react-router-dom';
+import { analytics } from '@/services/analytics';
+import { markWizardCompleted } from '@/hooks/useWizardAnalytics';
+import { isPublicRoom } from '@/helpers/strings';
 
 interface FinishStepProps {
   formData: Settings;
@@ -58,6 +61,13 @@ export default function FinishStep({
   const handleSubmit = async (): Promise<void> => {
     try {
       await submitSettings(formData, actionsList);
+
+      markWizardCompleted();
+      analytics.trackWizardCompleted(
+        formData.gameMode || 'online',
+        isPublicRoom(formData.room || 'PUBLIC') ? 'public' : 'private',
+        Object.keys(formData.selectedActions || {}).length
+      );
 
       const willNavigate =
         currentRoom !== undefined && currentRoom?.toUpperCase() !== formData.room?.toUpperCase();

--- a/src/views/GameSettingsWizard/index.tsx
+++ b/src/views/GameSettingsWizard/index.tsx
@@ -14,7 +14,7 @@ import PlayerTopologyStep from './PlayerTopologyStep';
 import RoomStep from './RoomStep';
 import { Settings } from '@/types/Settings';
 import { Trans } from 'react-i18next';
-import { usesSoloActions } from '@/helpers/strings';
+import { isPublicRoom, usesSoloActions } from '@/helpers/strings';
 import { useMigration } from '@/context/migration';
 import { useParams, useSearchParams } from 'react-router-dom';
 import useSettingsToFormData from '@/hooks/useSettingsToFormData';
@@ -125,25 +125,25 @@ export default function GameSettingsWizard({ close }: GameSettingsWizardProps) {
   const isActionsLoadingWithMigration = isActionsLoading || isMigrationInProgress;
 
   // Analytics tracking for wizard funnel
-  const { trackStepNavigation } = useWizardAnalytics({
+  const { trackScreenView } = useWizardAnalytics({
     gameMode: formData.gameMode,
+    isPublicRoom: isPublicRoom(formData.room || 'PUBLIC'),
   });
+
+  // One screen-view per step entered (including the initial screen)
+  useEffect(() => {
+    if (step > 0) {
+      trackScreenView(step);
+    }
+  }, [step, trackScreenView]);
 
   const nextStep = (count?: number): void => {
     const newStep = !Number.isInteger(count) ? step + 1 : step + (count || 1);
-
-    // Track step progression to the destination step
-    trackStepNavigation(step, newStep);
-
     setStep(newStep);
   };
 
   const handleStepClick = (targetStep: number): void => {
     const normalizedTargetStep = formData.gameMode === 'solo' && targetStep === 2 ? 3 : targetStep;
-
-    // Track step navigation
-    trackStepNavigation(step, normalizedTargetStep);
-
     setStep(normalizedTargetStep);
   };
 

--- a/src/views/ManageGameBoards/index.tsx
+++ b/src/views/ManageGameBoards/index.tsx
@@ -23,8 +23,10 @@ import AccordionDetails from '@/components/Accordion/Details';
 import { AddCircle, Delete } from '@mui/icons-material';
 import { t } from 'i18next';
 import { useSettings } from '@/stores/settingsStore';
+import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 import useAuth from '@/context/hooks/useAuth';
 import { getOrCreateBoard, sendMessage } from '@/services/firebase';
+import { isPublicRoom } from '@/helpers/strings';
 import { AlertState } from '@/types';
 
 interface GameBoardProps {
@@ -38,8 +40,9 @@ export default function GameBoard({ open, close, isMobile }: GameBoardProps) {
   const [alert, setAlert] = useState<AlertState | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<number>(0);
   const [expandedElement, setExpandedElement] = useState<number>(0);
-  const settings = useSettings()[0];
+  const [settings, updateSettings] = useSettings();
   const { user } = useAuth();
+  const isPublic = isPublicRoom(settings?.room || 'PUBLIC');
 
   if (!gameBoards) {
     return null;
@@ -103,6 +106,11 @@ export default function GameBoard({ open, close, isMobile }: GameBoardProps) {
 
   const enableBoard = (board: any) => {
     activateBoard(board.id);
+    // Public rooms allow any board size — adopt the board's size so the rest
+    // of the app (builder, warnings, sharing) stays in sync with the tiles.
+    if (isPublic && board.tiles?.length && board.tiles.length !== settings?.roomTileCount) {
+      updateSettings({ roomTileCount: board.tiles.length });
+    }
     createGameMessage(board);
     setAlert({ message: t('boardEnabled'), type: 'success' });
   };
@@ -124,11 +132,12 @@ export default function GameBoard({ open, close, isMobile }: GameBoardProps) {
   };
 
   const invalidBoard = (board: any) =>
-    !board.tiles || board.tiles.length !== (settings?.roomTileCount || 40);
+    !board.tiles ||
+    (!isPublic && board.tiles.length !== (settings?.roomTileCount || DEFAULT_TILE_COUNT));
 
   const getSwitchTooltip = (board: any) => {
     if (invalidBoard(board)) {
-      return t('boardWrongSize', { size: settings?.roomTileCount || 40 });
+      return t('boardWrongSize', { size: settings?.roomTileCount || DEFAULT_TILE_COUNT });
     }
     if (board.isActive) {
       return t('boardActive');

--- a/src/views/Room/index.tsx
+++ b/src/views/Room/index.tsx
@@ -61,6 +61,8 @@ export default function Room() {
   // Game session tracking
   const sessionStartTimeRef = useRef<number>(Date.now());
   const actionCountRef = useRef<number>(0);
+  const gameStartedRef = useRef<boolean>(false);
+  const gameFinishedRef = useRef<boolean>(false);
 
   // Roll button ref for keyboard shortcuts
   const rollButtonRef = useRef<RollButtonHandle>(null);
@@ -78,6 +80,7 @@ export default function Room() {
     setRollValue({ value: newValue, time: Date.now() });
     // Track action for session analytics
     actionCountRef.current += 1;
+    analytics.trackActionRolled(actionCountRef.current);
   }, []);
 
   const {
@@ -113,6 +116,35 @@ export default function Room() {
     );
   }, [settings, hybridPlayerList, localPlayers.length]);
 
+  // game_started + group_selected: fire once when the board is ready to play
+  useEffect(() => {
+    if (gameStartedRef.current || !gameBoard?.length) return;
+    if (!Object.keys(settings || {}).length) return;
+
+    gameStartedRef.current = true;
+    const selectedActions = settings.selectedActions || {};
+    analytics.trackGameStarted({
+      topology: settings.gameMode || 'unknown',
+      room_type: room.toUpperCase() === 'PUBLIC' ? 'public' : 'private',
+      group_count: Object.keys(selectedActions).length,
+      board_size: gameBoard.length,
+    });
+    Object.entries(selectedActions).forEach(([groupName, entry]) => {
+      analytics.trackGroupSelected(groupName, entry?.levels || [], entry?.type || 'unknown');
+    });
+  }, [gameBoard, settings, room]);
+
+  // game_finished: fires once when the local player lands on the finish tile
+  useEffect(() => {
+    if (gameFinishedRef.current || !gameBoard?.length || actionCountRef.current === 0) return;
+    if (tile?.index === gameBoard.length - 1) {
+      gameFinishedRef.current = true;
+      const duration = Date.now() - sessionStartTimeRef.current;
+      const { gameMode, playerCount } = lastCountsRef.current;
+      analytics.trackGameFinished(actionCountRef.current, duration, gameMode, playerCount);
+    }
+  }, [tile, gameBoard]);
+
   // Track game session on component unmount only
   useEffect(() => {
     const start = sessionStartTimeRef.current;
@@ -120,6 +152,10 @@ export default function Room() {
       const duration = Date.now() - start;
       const { gameMode, playerCount } = lastCountsRef.current;
       analytics.trackGameSession(duration, actionCountRef.current, gameMode, playerCount);
+      // Left mid-game with rolls on the board and never reached the finish tile
+      if (actionCountRef.current > 0 && !gameFinishedRef.current) {
+        analytics.trackGameAbandoned(actionCountRef.current, duration, gameMode, playerCount);
+      }
     };
   }, []);
   const { roller } = usePrivateRoomMonitor(room, gameBoard);


### PR DESCRIPTION
## Phase 0 of the growth plan (`docs/plans/growth-flywheel-2026-07.md`)

First of four phase PRs. Ships the measurement baseline before any funnel/UI changes, plus the two zero-UI game-length fixes.

### Analytics rework (GA4 only, no new infra)
- **Wizard funnel**: `wizard_screen_view` (one per step entered), `wizard_completed` (on settings submit), `wizard_abandoned` (unmount without completing, tagged with last screen) — replaces the old `funnel_step` event.
- **Game lifecycle**: `game_started` (topology, group count, board size) + one `group_selected` per actually-picked group; `action_rolled` (running count); `game_finished` when the finish tile is reached; `game_abandoned` when leaving mid-game with rolls on the board. Answers: are they trying the game? rolling? getting to the end?
- **Pack flywheel**: `pack_directory_viewed`, `pack_previewed`, `pack_imported`, `pack_published` wired through `contentPacks.ts` and the directory/preview components.
- **Seeding noise killed**: `custom_group_action` no longer fires when migration seeds default groups per user/locale (that noise made ballBusting ≈ kissing in GA4 — every user's DB seeds both). Only user-authored group CRUD is tracked now.
- Same privacy rules as before: no display names, room codes, or action text.

### Board size
- Default 40 → 60 tiles via new `DEFAULT_TILE_COUNT` constant (was scattered `|| 40` literals).
- **Public rooms now respect the user's `roomTileCount`** instead of forcing 40 — each player has their own board there; only private rooms require uniform size (shared positions).
- Importing a shared board (or activating one in a public room) **adopts the board's size into settings** instead of flagging it "wrong size."

### Notes
- `npm run type-check` clean; changed-file lint clean (warnings pre-existing); full CI suite 1437 passed.
- `src/stores/__tests__/gameBoard.test.ts` has one failure that **pre-exists on the base branch** (verified via stash) — untouched here.
- Also adds the agreed growth plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer analytics for wizard progress, gameplay, and content-pack activity.
  * Improved default board sizing across setup, import, and gameplay, with support for larger boards.
  * Added content-pack directory, preview, import, publish, and republish tracking.

* **Bug Fixes**
  * Public rooms now respect the selected board size instead of always using a fixed size.
  * Imported boards now keep their actual size during setup and gameplay.
  * Board warnings and compatibility checks now use the updated default size consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->