### PR TITLE
fix(packs): extension-merge corruption, republish, board-size & lifecycle bugs

### DIFF
--- a/src/hooks/useUrlImport.ts
+++ b/src/hooks/useUrlImport.ts
@@ -85,7 +85,9 @@ export default function useUrlImport(
 
       // Adopt the imported board's size so settings and board stay in sync
       // even when the author's saved settings disagree with the actual tiles.
-      finalSettings.roomTileCount = importedGameBoard.length;
+      // roomTileCount is a CONTENT count; the board array also holds the start
+      // and finish tiles, so subtract those two.
+      finalSettings.roomTileCount = Math.max(0, importedGameBoard.length - 2);
 
       setSettings(finalSettings);
 

--- a/src/services/__tests__/importExport.test.ts
+++ b/src/services/__tests__/importExport.test.ts
@@ -532,9 +532,7 @@ describe('ImportExport Service', () => {
         ...mockExportData,
         data: {
           customGroups: [],
-          customTiles: [
-            { ...mockExportData.data.customTiles[0], groupName: 'nonexistentGroup' },
-          ],
+          customTiles: [{ ...mockExportData.data.customTiles[0], groupName: 'nonexistentGroup' }],
           disabledDefaultTiles: [],
         },
       };
@@ -1050,6 +1048,84 @@ describe('ImportExport Service', () => {
         expect(group2?.exportCount.customTiles).toBe(1); // One custom tile
         expect(group2?.exportCount.disabledDefaults).toBe(1); // One disabled default
         expect(group2?.exportCount.total).toBe(3); // Total matches sum
+      });
+    });
+
+    describe('composite-key group resolution (mixed locale/gameMode payloads)', () => {
+      it('routes same-named extensions to the correct gameMode group', async () => {
+        const onlineGroup: CustomGroupPull = {
+          id: 'bb-en-online',
+          name: 'ballBusting',
+          label: 'Ball Busting',
+          intensities: [
+            { id: 'd1', label: 'L1', value: 1, isDefault: true },
+            { id: 'd2', label: 'L2', value: 2, isDefault: true },
+          ],
+          type: 'sex',
+          isDefault: true,
+          locale: 'en',
+          gameMode: 'online',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        const localGroup: CustomGroupPull = {
+          ...onlineGroup,
+          id: 'bb-en-local',
+          gameMode: 'local',
+        };
+
+        vi.mocked(getCustomGroups).mockImplementation((filters: any) =>
+          Promise.resolve(
+            filters?.gameMode === 'local'
+              ? [localGroup]
+              : filters?.gameMode === 'online'
+                ? [onlineGroup]
+                : []
+          )
+        );
+        vi.mocked(getTiles).mockResolvedValue([]);
+
+        const payload: ExportData = {
+          formatVersion: '2.1.0',
+          exportedAt: new Date().toISOString(),
+          data: {
+            customGroups: [],
+            customTiles: [],
+            disabledDefaultTiles: [],
+            groupExtensions: [
+              {
+                groupName: 'ballBusting',
+                groupLabel: 'Ball Busting',
+                locale: 'en',
+                gameMode: 'online',
+                addedIntensities: [{ value: 3, label: 'Online Extra' }],
+                contentHash: 'h1',
+              },
+              {
+                groupName: 'ballBusting',
+                groupLabel: 'Ball Busting',
+                locale: 'en',
+                gameMode: 'local',
+                addedIntensities: [{ value: 4, label: 'Local Extra' }],
+                contentHash: 'h2',
+              },
+            ],
+          },
+        };
+
+        await importData(payload);
+
+        const onlineCall = vi
+          .mocked(updateCustomGroup)
+          .mock.calls.find((c) => c[0] === 'bb-en-online');
+        const localCall = vi
+          .mocked(updateCustomGroup)
+          .mock.calls.find((c) => c[0] === 'bb-en-local');
+
+        expect(onlineCall).toBeDefined();
+        expect(localCall).toBeDefined();
+        expect((onlineCall![1] as any).intensities.map((i: any) => i.value)).toEqual([1, 2, 3]);
+        expect((localCall![1] as any).intensities.map((i: any) => i.value)).toEqual([1, 2, 4]);
       });
     });
   });

--- a/src/services/__tests__/importExport.test.ts
+++ b/src/services/__tests__/importExport.test.ts
@@ -1127,6 +1127,72 @@ describe('ImportExport Service', () => {
         expect((onlineCall![1] as any).intensities.map((i: any) => i.value)).toEqual([1, 2, 3]);
         expect((localCall![1] as any).intensities.map((i: any) => i.value)).toEqual([1, 2, 4]);
       });
+
+      it('disables a non-en default tile by recovering locale from the extension entry', async () => {
+        const frGroup: CustomGroupPull = {
+          id: 'bb-fr-online',
+          name: 'ballBusting',
+          label: 'Coups aux testicules',
+          intensities: [{ id: 'd1', label: 'N1', value: 1, isDefault: true }],
+          type: 'sex',
+          isDefault: true,
+          locale: 'fr',
+          gameMode: 'online',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        vi.mocked(getCustomGroups).mockImplementation((filters: any) =>
+          Promise.resolve(filters?.locale === 'fr' ? [frGroup] : [])
+        );
+        // Context build queries by group_id (custom tiles) → none; the disable
+        // lookup queries by isCustom:0 + action → the default tile to disable.
+        vi.mocked(getTiles).mockImplementation((f: any) =>
+          Promise.resolve(
+            f?.isCustom === 0 && f?.action
+              ? ([{ id: 99, action: 'Frapper', intensity: 1, isEnabled: 1 }] as any)
+              : []
+          )
+        );
+
+        const payload: ExportData = {
+          formatVersion: '2.1.0',
+          exportedAt: new Date().toISOString(),
+          data: {
+            customGroups: [],
+            customTiles: [],
+            disabledDefaultTiles: [
+              {
+                action: 'Frapper',
+                groupName: 'ballBusting',
+                intensity: 1,
+                gameMode: 'online',
+                contentHash: 'h',
+              },
+            ],
+            // Provides the fr locale the disabled-default entry lacks.
+            groupExtensions: [
+              {
+                groupName: 'ballBusting',
+                groupLabel: 'Coups',
+                locale: 'fr',
+                gameMode: 'online',
+                addedIntensities: [],
+                contentHash: 'hx',
+              },
+            ],
+          },
+        };
+
+        await importData(payload, { preserveDisabledDefaults: true });
+
+        // The fr default tile (id 99) is disabled — proof the locale resolved to
+        // 'fr', not the forced 'en' that would have missed the group entirely.
+        expect(vi.mocked(updateCustomTile)).toHaveBeenCalledWith(
+          99,
+          expect.objectContaining({ isEnabled: 0 })
+        );
+      });
     });
   });
 });

--- a/src/services/__tests__/intensityMerge.test.ts
+++ b/src/services/__tests__/intensityMerge.test.ts
@@ -38,12 +38,24 @@ describe('appendIntensities', () => {
     expect(result.merged.slice(0, 2)).toEqual(snapshot);
   });
 
-  it('skips duplicate values (idempotent re-import)', () => {
+  it('skips duplicate values with the same label (idempotent re-import)', () => {
     const existing = [...ladder([1, 2]), ...ladder([3], false)];
-    const result = appendIntensities(existing, [{ value: 3, label: 'Again' }], 'g');
+    // Same value AND same label as the existing level 3 → a true no-op.
+    const result = appendIntensities(existing, [{ value: 3, label: 'Level 3' }], 'g');
 
     expect(result.added).toEqual([]);
     expect(result.skipped).toEqual([{ value: 3, reason: 'duplicate' }]);
+    expect(result.merged).toEqual([...existing].sort((a, b) => a.value - b.value));
+  });
+
+  it('flags a value collision when the label differs (mislabel risk)', () => {
+    const existing = [...ladder([1, 2]), ...ladder([3], false)];
+    // Same value 3 but a DIFFERENT label: the incoming level means something
+    // else. It must not be silently swallowed as a duplicate.
+    const result = appendIntensities(existing, [{ value: 3, label: 'Brutal' }], 'g');
+
+    expect(result.added).toEqual([]);
+    expect(result.skipped).toEqual([{ value: 3, reason: 'valueConflict' }]);
     expect(result.merged).toEqual([...existing].sort((a, b) => a.value - b.value));
   });
 
@@ -83,7 +95,7 @@ describe('appendIntensities', () => {
 
     const full = appendIntensities(
       ladder([1, 2, 3, 4, 5, 6, 7, 8, 9, 10].slice(0, 10)),
-      [{ value: 10, label: 'Ten' }],
+      [{ value: 10, label: 'Level 10' }],
       'g'
     );
     expect(full.added).toEqual([]);

--- a/src/services/contentPacks.ts
+++ b/src/services/contentPacks.ts
@@ -316,9 +316,16 @@ export async function importPack(pack: ContentPackDoc): Promise<ImportResult> {
 
   if (result.success) {
     // Popularity counter; never let it fail the import (offline, rules, etc).
-    Promise.resolve(updateDoc(doc(db, COLLECTION, pack.id), { importCount: increment(1) })).catch(
-      () => {}
-    );
+    // Wrapped in an async IIFE so a synchronous throw from updateDoc (e.g. a
+    // bad ref) is caught too — a bare Promise.resolve(updateDoc(...)) would let
+    // a sync throw escape the .catch and reject the import.
+    void (async () => {
+      try {
+        await updateDoc(doc(db, COLLECTION, pack.id), { importCount: increment(1) });
+      } catch {
+        // Best-effort; ignore.
+      }
+    })();
 
     analytics.trackPackEvent('pack_imported', {
       group_count: pack.groupCount,

--- a/src/services/importExport.ts
+++ b/src/services/importExport.ts
@@ -48,7 +48,10 @@ interface ImportContext {
 // mixed payload's last section clobber the first, misdirecting extensions and
 // tiles onto the wrong group's ladder. Key by the full identity instead.
 function groupKey(name: string, locale: string, gameMode: string): string {
-  return `${name}|${locale}|${gameMode}`;
+  // Raw import JSON isn't constrained to known locale/gameMode enums here, and
+  // group names are user-authored, so a plain `|` join could be ambiguous
+  // (e.g. name "a|b" vs locale "b"). JSON-encode for a collision-proof key.
+  return JSON.stringify([name, locale, gameMode]);
 }
 
 interface ProgressCallback {

--- a/src/services/importExport.ts
+++ b/src/services/importExport.ts
@@ -35,12 +35,20 @@ const BATCH_SIZE = 100;
 
 // Enhanced types for better performance and maintainability
 interface ImportContext {
-  groupMap: Map<string, CustomGroupPull>; // groupName -> group
-  groupIdMap: Map<string, string>; // groupName -> groupId
+  groupMap: Map<string, CustomGroupPull>; // groupKey -> group
+  groupIdMap: Map<string, string>; // groupKey -> groupId
   existingTileMap: Map<string, CustomTile>; // action+intensity+groupId -> tile
   result: ImportResult;
   importData: ExportData;
   options: ImportOptions;
+}
+
+// Default group names repeat across locales AND game modes (en/local vs
+// en/online both have "ballBusting"). Keying group maps by name alone lets a
+// mixed payload's last section clobber the first, misdirecting extensions and
+// tiles onto the wrong group's ladder. Key by the full identity instead.
+function groupKey(name: string, locale: string, gameMode: string): string {
+  return `${name}|${locale}|${gameMode}`;
 }
 
 interface ProgressCallback {
@@ -91,8 +99,12 @@ async function buildImportContext(
     }
   }
 
-  const groupMap = new Map(allExistingGroups.map((g) => [g.name, g]));
-  const groupIdMap = new Map(allExistingGroups.map((g) => [g.name, g.id]));
+  const groupMap = new Map(
+    allExistingGroups.map((g) => [groupKey(g.name, g.locale, g.gameMode), g])
+  );
+  const groupIdMap = new Map(
+    allExistingGroups.map((g) => [groupKey(g.name, g.locale, g.gameMode), g.id])
+  );
 
   // Pre-load existing tiles for conflict detection
   const existingTileMap = new Map<string, CustomTile>();
@@ -165,7 +177,8 @@ async function createExportDisabled(
 async function processGroupImport(ctx: ImportContext): Promise<void> {
   for (const importedGroup of ctx.importData.data.customGroups) {
     try {
-      const existingGroup = ctx.groupMap.get(importedGroup.name);
+      const key = groupKey(importedGroup.name, importedGroup.locale, importedGroup.gameMode);
+      const existingGroup = ctx.groupMap.get(key);
 
       if (existingGroup?.isDefault) {
         // Never let an import replace a default group's record — that would
@@ -208,8 +221,8 @@ async function processGroupImport(ctx: ImportContext): Promise<void> {
           updatedAt: new Date(),
         } as CustomGroupPull;
 
-        ctx.groupMap.set(importedGroup.name, newGroupData);
-        ctx.groupIdMap.set(importedGroup.name, newGroupId);
+        ctx.groupMap.set(key, newGroupData);
+        ctx.groupIdMap.set(key, newGroupId);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -221,7 +234,8 @@ async function processGroupImport(ctx: ImportContext): Promise<void> {
 async function processGroupExtensions(ctx: ImportContext): Promise<void> {
   for (const extension of ctx.importData.data.groupExtensions ?? []) {
     try {
-      let group = ctx.groupMap.get(extension.groupName);
+      const key = groupKey(extension.groupName, extension.locale, extension.gameMode);
+      let group = ctx.groupMap.get(key);
 
       if (!group) {
         // Same deterministic-id resolution the tile importer uses for
@@ -238,8 +252,8 @@ async function processGroupExtensions(ctx: ImportContext): Promise<void> {
         const defaultGroup = allGroups.find((g) => g.id === calculatedGroupId);
         if (defaultGroup) {
           group = defaultGroup;
-          ctx.groupMap.set(extension.groupName, defaultGroup);
-          ctx.groupIdMap.set(extension.groupName, defaultGroup.id);
+          ctx.groupMap.set(key, defaultGroup);
+          ctx.groupIdMap.set(key, defaultGroup.id);
         }
       }
 
@@ -267,6 +281,13 @@ async function processGroupExtensions(ctx: ImportContext): Promise<void> {
         if (skip.reason === 'duplicate') {
           // Expected on re-import; not worth a warning.
           ctx.result.skippedItems++;
+        } else if (skip.reason === 'valueConflict') {
+          // Safety-relevant: the pack's level N differs in meaning from the
+          // existing level N. It is not applied, and any pack tiles at this
+          // intensity will inherit the EXISTING label — warn loudly.
+          ctx.result.warnings.push(
+            `Intensity level ${skip.value} for "${extension.groupName}" already exists with a different label; the pack's level was not applied, and its tiles at this level will use your existing label.`
+          );
         } else {
           ctx.result.warnings.push(
             `Skipped intensity ${skip.value} for ${extension.groupName}: ${skip.reason}`
@@ -279,12 +300,10 @@ async function processGroupExtensions(ctx: ImportContext): Promise<void> {
       await updateCustomGroup(group.id, { intensities: merged });
       ctx.result.importedIntensities += added.length;
       // Refresh the map so tiles at the new levels pass intensity validation.
-      ctx.groupMap.set(extension.groupName, { ...group, intensities: merged });
+      ctx.groupMap.set(key, { ...group, intensities: merged });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      ctx.result.errors.push(
-        `Failed to import extension for ${extension.groupName}: ${message}`
-      );
+      ctx.result.errors.push(`Failed to import extension for ${extension.groupName}: ${message}`);
     }
   }
 }
@@ -301,8 +320,9 @@ async function processTileImport(ctx: ImportContext): Promise<void> {
 
     for (const importedTile of batch) {
       try {
-        let groupId = ctx.groupIdMap.get(importedTile.groupName);
-        let group = ctx.groupMap.get(importedTile.groupName);
+        const key = groupKey(importedTile.groupName, importedTile.locale, importedTile.gameMode);
+        let groupId = ctx.groupIdMap.get(key);
+        let group = ctx.groupMap.get(key);
 
         // If group not found, try to calculate the ID for default groups
         if (!groupId || !group) {
@@ -324,8 +344,8 @@ async function processTileImport(ctx: ImportContext): Promise<void> {
             groupId = calculatedGroupId;
             group = defaultGroup;
             // Add to maps for future lookups in this import session
-            ctx.groupIdMap.set(importedTile.groupName, groupId);
-            ctx.groupMap.set(importedTile.groupName, group);
+            ctx.groupIdMap.set(key, groupId);
+            ctx.groupMap.set(key, group);
           } else {
             ctx.result.warnings.push(
               `Skipped tile for missing group: ${importedTile.groupName} (${importedTile.locale}/${importedTile.gameMode})`
@@ -390,16 +410,17 @@ async function processDisabledDefaultImport(ctx: ImportContext): Promise<void> {
   // Process disabled default tiles by setting them to disabled in the database
   for (const disabledTile of ctx.importData.data.disabledDefaultTiles) {
     try {
-      let groupId = ctx.groupIdMap.get(disabledTile.groupName);
+      // ExportDisabledDefault carries no locale; recover it from the matching
+      // imported group (same name+gameMode), falling back to 'en'.
+      const importedGroup = ctx.importData.data.customGroups.find(
+        (g) => g.name === disabledTile.groupName && g.gameMode === disabledTile.gameMode
+      );
+      const groupLocale = importedGroup?.locale || 'en';
+      const key = groupKey(disabledTile.groupName, groupLocale, disabledTile.gameMode);
+      let groupId = ctx.groupIdMap.get(key);
 
       // If group not found, try to calculate the ID for default groups
       if (!groupId) {
-        // Find the locale from the corresponding imported group, fallback to 'en'
-        const importedGroup = ctx.importData.data.customGroups.find(
-          (g) => g.name === disabledTile.groupName && g.gameMode === disabledTile.gameMode
-        );
-        const groupLocale = importedGroup?.locale || 'en';
-
         // Calculate deterministic ID for default groups using correct locale
         const calculatedGroupId = createDeterministicGroupId(
           disabledTile.groupName,
@@ -417,8 +438,8 @@ async function processDisabledDefaultImport(ctx: ImportContext): Promise<void> {
         if (defaultGroup) {
           groupId = calculatedGroupId;
           // Add to map for future lookups in this import session
-          ctx.groupIdMap.set(disabledTile.groupName, groupId);
-          ctx.groupMap.set(disabledTile.groupName, defaultGroup);
+          ctx.groupIdMap.set(key, groupId);
+          ctx.groupMap.set(key, defaultGroup);
         } else {
           ctx.result.warnings.push(
             `Skipped disabled default for missing group: ${disabledTile.groupName}`
@@ -645,7 +666,12 @@ export async function exportAllData(
       const addedIntensities = group.intensities
         .filter((i) => !i.isDefault)
         .map((i) => ({ value: i.value, label: i.label }));
-      if (addedIntensities.length === 0) continue;
+      // A default group can contribute custom tiles at EXISTING levels without
+      // adding any new intensity level. Emit an entry for those too (empty
+      // addedIntensities) so the pack summary's extension count/labels match the
+      // actual contents; skip only default groups that contribute nothing.
+      const hasExportedTiles = allCustomTiles.some((t) => t.group_id === group.id);
+      if (addedIntensities.length === 0 && !hasExportedTiles) continue;
       exportExtensions.push({
         groupName: group.name,
         groupLabel: group.label || group.name,
@@ -741,7 +767,9 @@ export async function analyzeImportConflicts(
 
     // Group conflicts: an imported group whose name already exists locally.
     for (const imported of importData.data.customGroups) {
-      const existing = ctx.groupMap.get(imported.name);
+      const existing = ctx.groupMap.get(
+        groupKey(imported.name, imported.locale, imported.gameMode)
+      );
       if (!existing) continue;
       const existingHash = await generateGroupContentHash(existing);
       result.groupConflicts.push({
@@ -755,7 +783,8 @@ export async function analyzeImportConflicts(
     // exists locally. `contentMatch` flags a local edit — the existing content
     // differs from the imported one — so the UI can warn before overwriting.
     for (const imported of importData.data.customTiles) {
-      let groupId = ctx.groupIdMap.get(imported.groupName);
+      const key = groupKey(imported.groupName, imported.locale, imported.gameMode);
+      let groupId = ctx.groupIdMap.get(key);
       if (!groupId) {
         groupId = createDeterministicGroupId(
           imported.groupName,
@@ -763,7 +792,7 @@ export async function analyzeImportConflicts(
           imported.gameMode
         );
       }
-      const group = ctx.groupMap.get(imported.groupName);
+      const group = ctx.groupMap.get(key);
       const existing = ctx.existingTileMap.get(
         `${imported.action}_${imported.intensity}_${groupId}`
       );

--- a/src/services/importExport.ts
+++ b/src/services/importExport.ts
@@ -410,12 +410,21 @@ async function processDisabledDefaultImport(ctx: ImportContext): Promise<void> {
   // Process disabled default tiles by setting them to disabled in the database
   for (const disabledTile of ctx.importData.data.disabledDefaultTiles) {
     try {
-      // ExportDisabledDefault carries no locale; recover it from the matching
-      // imported group (same name+gameMode), falling back to 'en'.
-      const importedGroup = ctx.importData.data.customGroups.find(
-        (g) => g.name === disabledTile.groupName && g.gameMode === disabledTile.gameMode
-      );
-      const groupLocale = importedGroup?.locale || 'en';
+      // ExportDisabledDefault carries no locale. A disabled DEFAULT group is
+      // never in customGroups, so recover its locale from any sibling section
+      // that does carry one (its extension entry or one of its tiles), same
+      // name + gameMode, before falling back to 'en'.
+      const groupLocale =
+        ctx.importData.data.customGroups.find(
+          (g) => g.name === disabledTile.groupName && g.gameMode === disabledTile.gameMode
+        )?.locale ||
+        (ctx.importData.data.groupExtensions ?? []).find(
+          (e) => e.groupName === disabledTile.groupName && e.gameMode === disabledTile.gameMode
+        )?.locale ||
+        ctx.importData.data.customTiles.find(
+          (tl) => tl.groupName === disabledTile.groupName && tl.gameMode === disabledTile.gameMode
+        )?.locale ||
+        'en';
       const key = groupKey(disabledTile.groupName, groupLocale, disabledTile.gameMode);
       let groupId = ctx.groupIdMap.get(key);
 

--- a/src/services/intensityMerge.ts
+++ b/src/services/intensityMerge.ts
@@ -17,7 +17,11 @@ export interface IntensityAddition {
 
 export interface IntensitySkip {
   value: number;
-  reason: 'duplicate' | 'overCap' | 'outOfRange';
+  // 'duplicate' — same value AND same label already present (expected on
+  // re-import). 'valueConflict' — same value but a DIFFERENT label: the
+  // incoming level means something else and was NOT applied, so tiles at this
+  // value will carry the existing label (a mislabel risk callers must surface).
+  reason: 'duplicate' | 'valueConflict' | 'overCap' | 'outOfRange';
 }
 
 export interface IntensityMergeResult {
@@ -41,6 +45,7 @@ export function appendIntensities(
   groupName: string
 ): IntensityMergeResult {
   const takenValues = new Set(existing.map((i) => i.value));
+  const labelByValue = new Map(existing.map((i) => [i.value, i.label]));
   const added: CustomGroupIntensity[] = [];
   const skipped: IntensitySkip[] = [];
 
@@ -55,7 +60,14 @@ export function appendIntensities(
       continue;
     }
     if (takenValues.has(addition.value)) {
-      skipped.push({ value: addition.value, reason: 'duplicate' });
+      const existingLabel = labelByValue.get(addition.value);
+      skipped.push({
+        value: addition.value,
+        reason:
+          existingLabel !== undefined && existingLabel !== addition.label
+            ? 'valueConflict'
+            : 'duplicate',
+      });
       continue;
     }
     if (existing.length + added.length >= MAX_INTENSITIES_COUNT) {
@@ -63,6 +75,7 @@ export function appendIntensities(
       continue;
     }
     takenValues.add(addition.value);
+    labelByValue.set(addition.value, addition.label);
     added.push({
       id: extensionIntensityId(groupName, addition.value),
       label: addition.label,

--- a/src/views/CustomGroupDialog/ExtendDefaultGroupDialog.tsx
+++ b/src/views/CustomGroupDialog/ExtendDefaultGroupDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -49,7 +49,10 @@ export default function ExtendDefaultGroupDialog({
 }: ExtendDefaultGroupDialogProps) {
   const { t } = useTranslation();
 
-  const [newLabels, setNewLabels] = useState<string[]>([]);
+  // Each row carries a stable id so removing one never shifts another's key
+  // (array-index keys break focus/DOM identity on filter).
+  const [newLabels, setNewLabels] = useState<{ id: string; label: string }[]>([]);
+  const labelIdCounter = useRef(0);
   const [removedValues, setRemovedValues] = useState<Set<number>>(new Set());
   const [tileCountByValue, setTileCountByValue] = useState<Record<number, number>>({});
   const [errors, setErrors] = useState<string[]>([]);
@@ -106,11 +109,14 @@ export default function ExtendDefaultGroupDialog({
 
   const handleAdd = () => {
     if (ladderFull) return;
-    setNewLabels((prev) => [...prev, '']);
+    setNewLabels((prev) => [...prev, { id: `nl-${labelIdCounter.current++}`, label: '' }]);
   };
 
   const handleSave = async () => {
-    const validation = validateGroupExtension(keptLevels, newLabels);
+    const validation = validateGroupExtension(
+      keptLevels,
+      newLabels.map((entry) => entry.label)
+    );
     if (!validation.isValid) {
       setErrors(validation.errors);
       return;
@@ -122,10 +128,9 @@ export default function ExtendDefaultGroupDialog({
       // gap left by a removed level. Append-only sync merges by value, so
       // reusing a freed value lets two devices bind the same value to
       // different labels — a permanent, unresolvable divergence.
-      let nextValue = highestValue + 1;
-      const additions = newLabels.map((label) => ({
-        value: nextValue++,
-        label: label.trim(),
+      const additions = newLabels.map((entry, index) => ({
+        value: highestValue + index + 1,
+        label: entry.label.trim(),
       }));
 
       const { merged, added, skipped } = appendIntensities(keptLevels, additions, group.name);
@@ -223,12 +228,14 @@ export default function ExtendDefaultGroupDialog({
           );
         })}
 
-        {newLabels.map((label, index) => (
-          <Box key={`new-${index}`} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        {newLabels.map((entry) => (
+          <Box key={entry.id} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <TextField
-              value={label}
+              value={entry.label}
               onChange={(e) =>
-                setNewLabels((prev) => prev.map((l, i) => (i === index ? e.target.value : l)))
+                setNewLabels((prev) =>
+                  prev.map((l) => (l.id === entry.id ? { ...l, label: e.target.value } : l))
+                )
               }
               placeholder={t('customGroups.newLevelPlaceholder')}
               size="small"
@@ -238,7 +245,7 @@ export default function ExtendDefaultGroupDialog({
             <IconButton
               size="small"
               aria-label="remove new level"
-              onClick={() => setNewLabels((prev) => prev.filter((_, i) => i !== index))}
+              onClick={() => setNewLabels((prev) => prev.filter((l) => l.id !== entry.id))}
               color="error"
             >
               <DeleteIcon fontSize="small" />

--- a/src/views/CustomGroupDialog/ExtendDefaultGroupDialog.tsx
+++ b/src/views/CustomGroupDialog/ExtendDefaultGroupDialog.tsx
@@ -109,14 +109,15 @@ export default function ExtendDefaultGroupDialog({
 
     setIsSaving(true);
     try {
-      // Assign the lowest free values to the new levels, in row order.
-      const taken = new Set(keptLevels.map((i) => i.value));
-      const additions = newLabels.map((label) => {
-        let value = 1;
-        while (taken.has(value)) value++;
-        taken.add(value);
-        return { value, label: label.trim() };
-      });
+      // Allocate strictly above the current highest value, never reusing a
+      // gap left by a removed level. Append-only sync merges by value, so
+      // reusing a freed value lets two devices bind the same value to
+      // different labels — a permanent, unresolvable divergence.
+      let nextValue = keptLevels.reduce((max, i) => Math.max(max, i.value), 0) + 1;
+      const additions = newLabels.map((label) => ({
+        value: nextValue++,
+        label: label.trim(),
+      }));
 
       const { merged } = appendIntensities(keptLevels, additions, group.name);
       await updateCustomGroup(group.id, { intensities: merged });
@@ -208,10 +209,7 @@ export default function ExtendDefaultGroupDialog({
         })}
 
         {newLabels.map((label, index) => (
-          <Box
-            key={`new-${index}`}
-            sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}
-          >
+          <Box key={`new-${index}`} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <TextField
               value={label}
               onChange={(e) =>

--- a/src/views/CustomGroupDialog/ExtendDefaultGroupDialog.tsx
+++ b/src/views/CustomGroupDialog/ExtendDefaultGroupDialog.tsx
@@ -22,7 +22,11 @@ import type { CustomGroupPull, CustomGroupIntensity } from '@/types/customGroups
 import { updateCustomGroup } from '@/stores/customGroups';
 import { getTiles } from '@/stores/customTiles';
 import { appendIntensities } from '@/services/intensityMerge';
-import { validateGroupExtension, MAX_INTENSITIES_COUNT } from '@/services/validationService';
+import {
+  validateGroupExtension,
+  MAX_INTENSITIES_COUNT,
+  MAX_INTENSITY_VALUE,
+} from '@/services/validationService';
 
 export interface ExtendDefaultGroupDialogProps {
   open: boolean;
@@ -93,7 +97,12 @@ export default function ExtendDefaultGroupDialog({
   ].sort((a, b) => a.value - b.value);
 
   const totalLevels = keptLevels.length + newLabels.length;
-  const ladderFull = totalLevels >= MAX_INTENSITIES_COUNT;
+  // Two independent ceilings: the level COUNT cap, and the VALUE cap — since
+  // values are allocated strictly above the current highest (never reusing a
+  // freed gap), the next value must still fit within MAX_INTENSITY_VALUE.
+  const highestValue = keptLevels.reduce((max, i) => Math.max(max, i.value), 0);
+  const valueCeilingReached = highestValue + newLabels.length >= MAX_INTENSITY_VALUE;
+  const ladderFull = totalLevels >= MAX_INTENSITIES_COUNT || valueCeilingReached;
 
   const handleAdd = () => {
     if (ladderFull) return;
@@ -113,13 +122,19 @@ export default function ExtendDefaultGroupDialog({
       // gap left by a removed level. Append-only sync merges by value, so
       // reusing a freed value lets two devices bind the same value to
       // different labels — a permanent, unresolvable divergence.
-      let nextValue = keptLevels.reduce((max, i) => Math.max(max, i.value), 0) + 1;
+      let nextValue = highestValue + 1;
       const additions = newLabels.map((label) => ({
         value: nextValue++,
         label: label.trim(),
       }));
 
-      const { merged } = appendIntensities(keptLevels, additions, group.name);
+      const { merged, added, skipped } = appendIntensities(keptLevels, additions, group.name);
+      // Never report success while silently dropping a level (e.g. a value that
+      // would exceed MAX_INTENSITY_VALUE). Surface it instead of closing.
+      if (skipped.length > 0 || added.length !== newLabels.length) {
+        setErrors([t('customGroups.ladderFull')]);
+        return;
+      }
       await updateCustomGroup(group.id, { intensities: merged });
       onSaved({ ...group, intensities: merged });
       onClose();

--- a/src/views/CustomTileDialog/Packs/PackImportDialog.tsx
+++ b/src/views/CustomTileDialog/Packs/PackImportDialog.tsx
@@ -59,8 +59,9 @@ export default function PackImportDialog({
   const declaredExtensions = parsed?.data.data.groupExtensions ?? [];
 
   // Tiles can target default groups without a matching groupExtensions entry
-  // (e.g. new actions at existing levels). Surface those as synthetic
-  // extension sections so no tile is invisible in the preview.
+  // (e.g. new actions at existing levels). The exporter now emits an entry for
+  // every contributing default group, so this only fires for packs published
+  // before that fix — a backward-compat net so no tile is invisible.
   const extensions = useMemo(() => {
     const covered = new Set([
       ...groups.map((g) => g.name),
@@ -173,7 +174,8 @@ export default function PackImportDialog({
         </Box>
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
           {t('packs.summary', { groups: groups.length, tiles: tiles.length })}
-          {extensions.length > 0 && ` · ${t('packs.extensionSummary', { count: extensions.length })}`}
+          {extensions.length > 0 &&
+            ` · ${t('packs.extensionSummary', { count: extensions.length })}`}
         </Typography>
       </Box>
 
@@ -300,8 +302,7 @@ export default function PackImportDialog({
                 ])
               );
               const colorFor = (value: number) => colorByValue.get(value) ?? 'primary.main';
-              const intensityLabel = (value: number) =>
-                addedLabelByValue.get(value) ?? `L${value}`;
+              const intensityLabel = (value: number) => addedLabelByValue.get(value) ?? `L${value}`;
               return (
                 <Box key={`ext-${extension.groupName}`}>
                   <Box

--- a/src/views/GameSettings/index.tsx
+++ b/src/views/GameSettings/index.tsx
@@ -25,12 +25,16 @@ interface GameSettingsProps {
   closeDialog?: () => void;
   initialTab?: number;
   onOpenSetupWizard?: () => void;
+  /** Fires after a successful settings submit; lets the wizard mark the funnel
+   * complete so finishing via Advanced Setup isn't logged as an abandonment. */
+  onCompleted?: (groupCount: number) => void;
 }
 
 export default function GameSettings({
   closeDialog,
   initialTab = 0,
   onOpenSetupWizard,
+  onCompleted,
 }: GameSettingsProps): JSX.Element {
   const { user } = useAuth();
   const { t } = useTranslation();
@@ -65,13 +69,15 @@ export default function GameSettings({
 
       await submitSettings(formData, actionsList);
 
+      onCompleted?.(Object.keys(gameOptions.selectedActions || {}).length);
+
       if (typeof closeDialog === 'function') {
         closeDialog();
       }
 
       return null;
     },
-    [formData, actionsList, t, setAlert, submitSettings, closeDialog]
+    [formData, actionsList, t, setAlert, submitSettings, closeDialog, onCompleted]
   );
 
   const handleBlur = useCallback(

--- a/src/views/GameSettingsWizard/ActionsStep/SpiceDial.tsx
+++ b/src/views/GameSettingsWizard/ActionsStep/SpiceDial.tsx
@@ -6,19 +6,22 @@ export type SpiceLevel = 'mild' | 'medium' | 'spicy' | 'filthy';
 export const SPICE_LEVELS: SpiceLevel[] = ['mild', 'medium', 'spicy', 'filthy'];
 
 /**
- * Map a spice level to a cumulative level band for a group's ladder.
+ * Map a spice level to a cumulative band of a group's ACTUAL intensity values.
  * Bands scale by percentile so 3-, 4-, 5- and 6-level ladders all get a
- * sensible default without assuming a shared level semantic.
+ * sensible default. Returns real intensity values (not 1..k positions) so
+ * sparse ladders (e.g. [1, 2, 4, 5]) never select phantom levels downstream.
  */
-export function spiceBand(spice: SpiceLevel, ladderSize: number): number[] {
+export function spiceBand(spice: SpiceLevel, ladder: number[]): number[] {
   const fractions: Record<SpiceLevel, number> = {
     mild: 0.25,
     medium: 0.5,
     spicy: 0.75,
     filthy: 1,
   };
-  const top = Math.max(1, Math.round(ladderSize * fractions[spice]));
-  return Array.from({ length: Math.min(top, ladderSize) }, (_, i) => i + 1);
+  const sorted = [...ladder].sort((a, b) => a - b);
+  if (sorted.length === 0) return [];
+  const top = Math.max(1, Math.round(sorted.length * fractions[spice]));
+  return sorted.slice(0, Math.min(top, sorted.length));
 }
 
 interface SpiceDialProps {

--- a/src/views/GameSettingsWizard/ActionsStep/__tests__/spiceAndChips.test.ts
+++ b/src/views/GameSettingsWizard/ActionsStep/__tests__/spiceAndChips.test.ts
@@ -3,26 +3,37 @@ import { spiceBand } from '../SpiceDial';
 import { formatLevels } from '../GroupChips';
 
 describe('spiceBand', () => {
-  it('always selects at least level 1', () => {
-    expect(spiceBand('mild', 3)).toEqual([1]);
-    expect(spiceBand('mild', 4)).toEqual([1]);
-    expect(spiceBand('mild', 5)).toEqual([1]);
+  it('always selects at least the lowest level', () => {
+    expect(spiceBand('mild', [1, 2, 3])).toEqual([1]);
+    expect(spiceBand('mild', [1, 2, 3, 4])).toEqual([1]);
+    expect(spiceBand('mild', [1, 2, 3, 4, 5])).toEqual([1]);
   });
 
   it('scales the band with the ladder size', () => {
-    expect(spiceBand('medium', 4)).toEqual([1, 2]);
-    expect(spiceBand('medium', 6)).toEqual([1, 2, 3]);
-    expect(spiceBand('spicy', 4)).toEqual([1, 2, 3]);
+    expect(spiceBand('medium', [1, 2, 3, 4])).toEqual([1, 2]);
+    expect(spiceBand('medium', [1, 2, 3, 4, 5, 6])).toEqual([1, 2, 3]);
+    expect(spiceBand('spicy', [1, 2, 3, 4])).toEqual([1, 2, 3]);
   });
 
   it('filthy selects the whole ladder', () => {
-    expect(spiceBand('filthy', 3)).toEqual([1, 2, 3]);
-    expect(spiceBand('filthy', 6)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(spiceBand('filthy', [1, 2, 3])).toEqual([1, 2, 3]);
+    expect(spiceBand('filthy', [1, 2, 3, 4, 5, 6])).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
   it('never exceeds the ladder', () => {
-    expect(spiceBand('spicy', 1)).toEqual([1]);
-    expect(spiceBand('filthy', 1)).toEqual([1]);
+    expect(spiceBand('spicy', [1])).toEqual([1]);
+    expect(spiceBand('filthy', [1])).toEqual([1]);
+    expect(spiceBand('mild', [])).toEqual([]);
+  });
+
+  it('returns ACTUAL intensity values for sparse ladders, not 1..k positions', () => {
+    // A ladder that skips values (e.g. custom levels 2,4,6,8) must yield real
+    // values so downstream board building never selects a phantom level.
+    expect(spiceBand('medium', [2, 4, 6, 8])).toEqual([2, 4]);
+    expect(spiceBand('mild', [3, 7, 9])).toEqual([3]);
+    expect(spiceBand('filthy', [5, 10])).toEqual([5, 10]);
+    // Unsorted input is normalized.
+    expect(spiceBand('medium', [8, 2, 6, 4])).toEqual([2, 4]);
   });
 });
 

--- a/src/views/GameSettingsWizard/ActionsStep/index.tsx
+++ b/src/views/GameSettingsWizard/ActionsStep/index.tsx
@@ -120,7 +120,7 @@ export default function ActionsStep({
     const current = type === 'consumption' ? selectedConsumptions : selectedActionGroups;
     if (Object.keys(current).length >= max) return;
 
-    const band = spiceBand(spice, ladderOf(group).length);
+    const band = spiceBand(spice, ladderOf(group));
     handleLevelsChange(
       band,
       group,
@@ -147,14 +147,17 @@ export default function ActionsStep({
       return;
     }
     const entry = formData.selectedActions?.[group] as ActionEntry | undefined;
+    // Derive the type from the group's own definition first: after an
+    // uncheck-all the entry is gone, and falling back to `actionType` would
+    // re-add a consumption group as a main-board action group. The definition
+    // is authoritative regardless of the entry's presence.
+    const groupType = (actionsList[group]?.type || entry?.type || actionType) as any;
+    const variation =
+      groupType === 'consumption'
+        ? entry?.variation || (formData.isAppend ? 'appendMost' : 'standalone')
+        : entry?.variation || null;
     markCustomized(group);
-    handleLevelsChange(
-      levels,
-      group,
-      (entry?.type || actionType) as any,
-      setFormData,
-      entry?.variation || null
-    );
+    handleLevelsChange(levels, group, groupType, setFormData, variation);
   };
 
   // The dial reseeds every selected group the user hasn't touched.
@@ -164,7 +167,7 @@ export default function ActionsStep({
       if (customized.has(group)) return;
       const typedEntry = entry as ActionEntry;
       handleLevelsChange(
-        spiceBand(newSpice, ladderOf(group).length),
+        spiceBand(newSpice, ladderOf(group)),
         group,
         typedEntry.type as any,
         setFormData,
@@ -216,6 +219,13 @@ export default function ActionsStep({
     setDirectoryOpen(false);
     if (!pack) return;
 
+    // The wizard's action list is scoped to the UI language. A pack authored in
+    // another locale imports fine, but its groups never appear in this list, so
+    // auto-selecting them would silently consume cap slots with no visible chip
+    // and leave the built board short. Import + reload only on a locale mismatch.
+    const uiLocale = i18n.resolvedLanguage || 'en';
+    if ((pack.locale || uiLocale) !== uiLocale) return;
+
     const groups = await getCustomGroups({
       // importPack preserves each group's locale from the pack contents, which
       // can differ from the current UI language.
@@ -238,7 +248,10 @@ export default function ActionsStep({
       else actionSlots -= 1;
 
       handleLevelsChange(
-        spiceBand(spice, Math.max(1, group.intensities.length)),
+        spiceBand(
+          spice,
+          group.intensities.map((i) => i.value)
+        ),
         group.name,
         (group.type || actionType) as any,
         setFormData,

--- a/src/views/GameSettingsWizard/ActionsStep/index.tsx
+++ b/src/views/GameSettingsWizard/ActionsStep/index.tsx
@@ -187,11 +187,14 @@ export default function ActionsStep({
         const srcType = actionsList[item].type;
         if (!srcType || !(VALID_GROUP_TYPES as readonly string[]).includes(srcType)) return;
         const presetIntensity = preset.intensities?.[item] || defaultIntensity;
-        const availableIntensities = Object.keys(actionsList[item].intensities || {});
-        const maxLevel = availableIntensities.length;
+        // Slice actual sorted intensity VALUES, not 1..k positions, so sparse
+        // ladders don't select phantom levels (mirrors spiceBand).
+        const availableValues = Object.keys(actionsList[item].intensities || {})
+          .map(Number)
+          .sort((a, b) => a - b);
         targetActions[item] = {
           type: srcType as GroupType,
-          levels: Array.from({ length: Math.min(presetIntensity, maxLevel) }, (_, i) => i + 1),
+          levels: availableValues.slice(0, Math.min(presetIntensity, availableValues.length)),
         };
       }
     });

--- a/src/views/GameSettingsWizard/PlayerTopologyStep/index.tsx
+++ b/src/views/GameSettingsWizard/PlayerTopologyStep/index.tsx
@@ -72,28 +72,37 @@ export default function PlayerTopologyStep({
   };
 
   const selectSharedDevice = () => {
-    setFormData((prev) => ({
-      ...prev,
-      gameMode: 'local',
-      soloPlay: false,
-      room: generateRoomCode(),
-      roomRealtime: false,
-    }));
+    setFormData((prev) => {
+      // Re-tapping the already-selected card must not mint a fresh code — the
+      // user may have already shared it. Only generate when there's no usable
+      // room code for this mode yet.
+      const keepRoom = prev.gameMode === 'local' && !!prev.room && prev.room !== 'PUBLIC';
+      return {
+        ...prev,
+        gameMode: 'local',
+        soloPlay: false,
+        room: keepRoom ? prev.room : generateRoomCode(),
+        roomRealtime: false,
+      };
+    });
   };
 
   const selectIndividualDevices = () => {
     if (offline) return;
 
-    setFormData((prev) => ({
-      ...prev,
-      gameMode: 'online',
-      soloPlay: true,
-      room: generateRoomCode(),
-      roomRealtime: false,
-      hasLocalPlayers: false,
-      localPlayersData: undefined,
-      localPlayerSessionSettings: undefined,
-    }));
+    setFormData((prev) => {
+      const keepRoom = prev.gameMode === 'online' && !!prev.room && prev.room !== 'PUBLIC';
+      return {
+        ...prev,
+        gameMode: 'online',
+        soloPlay: true,
+        room: keepRoom ? prev.room : generateRoomCode(),
+        roomRealtime: false,
+        hasLocalPlayers: false,
+        localPlayersData: undefined,
+        localPlayerSessionSettings: undefined,
+      };
+    });
   };
 
   const cards = [

--- a/src/views/GameSettingsWizard/index.tsx
+++ b/src/views/GameSettingsWizard/index.tsx
@@ -226,7 +226,14 @@ export default function GameSettingsWizard({ close }: GameSettingsWizardProps) {
     }
   };
 
-  if (step === 0) return <GameSettings closeDialog={close} onOpenSetupWizard={goToSetupWizard} />;
+  if (step === 0)
+    return (
+      <GameSettings
+        closeDialog={close}
+        onOpenSetupWizard={goToSetupWizard}
+        onCompleted={markCompleted}
+      />
+    );
 
   return (
     <Box>

--- a/src/views/ManageGameBoards/index.tsx
+++ b/src/views/ManageGameBoards/index.tsx
@@ -111,13 +111,16 @@ export default function GameBoard({ open, close, isMobile }: GameBoardProps) {
     activateBoard(board.id);
     // Public rooms allow any board size — adopt the board's size so the rest
     // of the app (builder, warnings, sharing) stays in sync with the tiles.
+    // board.tiles includes the start + finish tiles, but roomTileCount is a
+    // content count, so subtract those two before adopting.
+    const contentTileCount = board.tiles?.length ? Math.max(0, board.tiles.length - 2) : 0;
     const adoptsSize =
-      isPublic && board.tiles?.length && board.tiles.length !== settings?.roomTileCount;
+      isPublic && board.tiles?.length && contentTileCount !== settings?.roomTileCount;
     const effectiveSettings = adoptsSize
-      ? { ...settings, roomTileCount: board.tiles.length }
+      ? { ...settings, roomTileCount: contentTileCount }
       : settings;
     if (adoptsSize) {
-      updateSettings({ roomTileCount: board.tiles.length });
+      updateSettings({ roomTileCount: contentTileCount });
     }
     // Pass the adopted size along so the saved board metadata isn't stale.
     createGameMessage(board, effectiveSettings);

--- a/src/views/PackCreator/index.tsx
+++ b/src/views/PackCreator/index.tsx
@@ -42,9 +42,10 @@ import {
   publishPack,
   republishPack,
 } from '@/services/contentPacks';
-import { addCustomTile } from '@/stores/customTiles';
+import { addCustomTile, getTiles } from '@/stores/customTiles';
 import { getCustomGroups } from '@/stores/customGroups';
 import { validateCustomTileWithGroups } from '@/services/validationService';
+import { normalizePlaceholders } from '@/services/placeholderAliasService';
 import { analytics } from '@/services/analytics';
 import useAuth from '@/context/hooks/useAuth';
 import { useGameSettings } from '@/stores/settingsStore';
@@ -63,7 +64,8 @@ function buildShareLink(packId: string): string {
 /** Minimal inline tile author so a blank-start pack never needs another dialog. */
 function QuickTileAdd({ locale, gameMode }: { locale: string; gameMode: string }) {
   const { t } = useTranslation();
-  const groups = useLiveQuery(() => getCustomGroups({ locale, gameMode }), [locale, gameMode]) ?? [];
+  const groups =
+    useLiveQuery(() => getCustomGroups({ locale, gameMode }), [locale, gameMode]) ?? [];
   const [open, setOpen] = useState(false);
   const [groupName, setGroupName] = useState('');
   const [intensity, setIntensity] = useState<number | ''>('');
@@ -78,16 +80,26 @@ function QuickTileAdd({ locale, gameMode }: { locale: string; gameMode: string }
     setSaving(true);
     setFeedback(null);
     try {
+      // Mirror the canonical author path: normalize localized placeholder
+      // tokens to canonical English before validation, dedup, and storage.
+      const normalizedAction = normalizePlaceholders(action.trim(), locale);
       const tile = {
         group_id: group.id,
         intensity: Number(intensity),
-        action: action.trim(),
+        action: normalizedAction,
         tags: [],
         isCustom: 1,
       } as CustomTile;
       const result = await validateCustomTileWithGroups(tile, locale, gameMode);
       if (!result.isValid) {
         setFeedback({ ok: false, message: result.errors.join(' ') });
+        return;
+      }
+      // Reject a duplicate (same group + intensity + action) rather than
+      // silently writing a second identical tile.
+      const existing = await getTiles({ group_id: group.id, intensity: Number(intensity) });
+      if (existing.some((existingTile) => existingTile.action === normalizedAction)) {
+        setFeedback({ ok: false, message: t('actionExists') });
         return;
       }
       await addCustomTile(tile);
@@ -175,7 +187,11 @@ export default function PackCreator() {
   const editId = searchParams.get('edit');
   const { settings } = useGameSettings();
   const { user, isAnonymous } = useAuth();
-  const locale = settings.locale || 'en';
+  const [editingPack, setEditingPack] = useState<ContentPackDoc | null>(null);
+  // When republishing, the pack's own locale is authoritative — a pack authored
+  // in another language must not be re-serialized under the current UI language
+  // (that would export empty contents). New packs use the UI locale.
+  const locale = editingPack?.locale || settings.locale || 'en';
 
   const [step, setStep] = useState(0);
   const [gameMode, setGameMode] = useState<string>(getContentGameMode(settings.gameMode));
@@ -183,10 +199,7 @@ export default function PackCreator() {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState('');
-  const [visibility, setVisibility] = useState<PackVisibility>(
-    isAnonymous ? 'private' : 'public'
-  );
-  const [editingPack, setEditingPack] = useState<ContentPackDoc | null>(null);
+  const [visibility, setVisibility] = useState<PackVisibility>(isAnonymous ? 'private' : 'public');
   const [myPacks, setMyPacks] = useState<ContentPackDoc[]>([]);
   const [groupDialogOpen, setGroupDialogOpen] = useState(false);
   const [publishing, setPublishing] = useState(false);
@@ -219,7 +232,13 @@ export default function PackCreator() {
     setTags((pack.tags || []).join(', '));
     setVisibility(isAnonymous ? 'private' : pack.visibility);
     const parsed = parsePack(pack);
-    const packGroupNames = (parsed?.data.data.customGroups || []).map((g) => g.name);
+    // Extensions-only packs carry no customGroups entry for the default groups
+    // they extend — seed those names too or the republish selection comes up
+    // empty and the extensions are dropped.
+    const packGroupNames = [
+      ...(parsed?.data.data.customGroups || []).map((g) => g.name),
+      ...(parsed?.data.data.groupExtensions || []).map((e) => e.groupName),
+    ];
     setSelectedGroups(packGroupNames);
     setShareLink(null);
     setStep(0);
@@ -290,7 +309,11 @@ export default function PackCreator() {
     navigate(`/${settings.room || 'PUBLIC'}`);
   };
 
-  const steps = [t('packCreator.stepContent'), t('packCreator.stepDetails'), t('packCreator.stepPublish')];
+  const steps = [
+    t('packCreator.stepContent'),
+    t('packCreator.stepDetails'),
+    t('packCreator.stepPublish'),
+  ];
   const nextDisabled =
     (step === 0 && selectedGroups.length === 0) || (step === 1 && name.trim().length === 0);
 
@@ -459,7 +482,9 @@ export default function PackCreator() {
               {isAnonymous ? (
                 <FormHelperText>{t('packs.anonymousPrivateOnly')}</FormHelperText>
               ) : (
-                visibility === 'public' && <FormHelperText>{t('packs.publicHelper')}</FormHelperText>
+                visibility === 'public' && (
+                  <FormHelperText>{t('packs.publicHelper')}</FormHelperText>
+                )
               )}
             </FormControl>
           </Stack>
@@ -489,7 +514,8 @@ export default function PackCreator() {
               {visibility === 'public' && !isAnonymous
                 ? t('packCreator.willBePublic')
                 : t('packCreator.willBePrivate')}
-              {editingPack && ` · ${t('packCreator.willBumpVersion', { version: editingPack.packVersion + 1 })}`}
+              {editingPack &&
+                ` · ${t('packCreator.willBumpVersion', { version: editingPack.packVersion + 1 })}`}
             </Typography>
             {shareLink ? (
               <Alert severity="success" sx={{ wordBreak: 'break-all' }}>

--- a/src/views/Room/index.tsx
+++ b/src/views/Room/index.tsx
@@ -356,7 +356,12 @@ export default function Room() {
       <ToastAlert
         type={packToast?.type || 'error'}
         open={!!packToast}
-        close={() => setPackToast(null)}
+        close={() => {
+          setPackToast(null);
+          // Also clear the hook's `failed` flag, else the effect re-fires the
+          // error toast on the next re-render (e.g. a language switch).
+          dismissPack();
+        }}
       >
         {packToast?.message}
       </ToastAlert>

--- a/src/views/Room/index.tsx
+++ b/src/views/Room/index.tsx
@@ -161,7 +161,16 @@ export default function Room() {
   }, []);
   const { roller } = usePrivateRoomMonitor(room, gameBoard);
   const [importResult, clearImportResult, isImporting] = useUrlImport(settings, setSettings as any);
-  const { pendingPack, dismiss: dismissPack } = useUrlPackImport();
+  const { pendingPack, failed: packFailed, dismiss: dismissPack } = useUrlPackImport();
+  // Surface share-link pack import outcomes — the fetch strips the `?importPack`
+  // param either way, so a silent failure or success leaves no trace otherwise.
+  const [packToast, setPackToast] = useState<{ type: 'success' | 'error'; message: string } | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (packFailed) setPackToast({ type: 'error', message: t('packs.importFailed') });
+  }, [packFailed, t]);
 
   // Keyboard shortcut: Spacebar to roll
   useEffect(() => {
@@ -335,8 +344,22 @@ export default function Room() {
         {importResult}
       </ToastAlert>
       {pendingPack && (
-        <PackImportDialog pack={pendingPack} open={!!pendingPack} onClose={dismissPack} />
+        <PackImportDialog
+          pack={pendingPack}
+          open={!!pendingPack}
+          onClose={dismissPack}
+          onImported={(name) =>
+            setPackToast({ type: 'success', message: t('packs.importedToast', { name }) })
+          }
+        />
       )}
+      <ToastAlert
+        type={packToast?.type || 'error'}
+        open={!!packToast}
+        close={() => setPackToast(null)}
+      >
+        {packToast?.message}
+      </ToastAlert>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes a batch of confirmed bugs from the pack-extension / growth-plan review (`e6cbe8e3..HEAD`), prioritizing the data-corruption and data-loss class first.

### Data corruption / data loss
- **Import maps keyed by group name alone collided across locale AND gameMode.** Default group names repeat (`en/local` vs `en/online` both have `ballBusting`), so a mixed payload's later section clobbered the earlier one in the `Map`, misdirecting **extensions and tiles** onto the wrong group's ladder. Re-keyed `groupMap`/`groupIdMap` by `name|locale|gameMode` across all four importers **and** `analyzeImportConflicts`.
- **Extension intensity collisions were silently swallowed.** An incoming level at an existing value but with a *different* label was skipped as a "duplicate." Now distinguished: same value + same label = silent `duplicate`; same value + different label = loud `valueConflict` warning (mislabeling is a safety issue here).
- **`ExtendDefaultGroupDialog` reused freed gap values.** Reusing a removed level's value fights append-only sync into permanent cross-device divergence. Now allocates `max(value)+1`.
- **Republish dropped extensions and used the wrong locale.** `enterEditMode` seeded selection from `customGroups` only (extensions-only packs couldn't republish), and republish re-serialized under the current UI language (empty contents). Now seeds `groupExtensions` names and derives locale from the pack.
- **Exporter omitted default groups contributing tiles-at-existing-levels**, so the pack summary (`extensionCount`/labels) diverged from actual contents. Now emits an entry for every contributing default group.

### Correctness
- `spiceBand` slices **actual sorted intensity values**, not `1..k` positions — sparse ladders no longer select phantom levels on the built board.
- `ActionsStep.editLevels` derives the group type from its definition, so uncheck-all-then-recheck no longer re-adds a consumption group as a main-board action.
- Cross-locale pack import skips auto-select (it would consume cap slots with no visible chip).
- `roomTileCount` adoption subtracts the start+finish tiles at both adoption sites (`useUrlImport`, enabling a public board) — it is a content count.
- `Room` surfaces share-link pack import success/failure (was silent both ways).
- `QuickTileAdd` normalizes placeholders and rejects duplicates like the canonical author path.
- `PlayerTopology` re-tapping the selected card preserves the existing (possibly shared) room code.
- Completing setup via Advanced Setup marks the wizard funnel complete (no false `wizard_abandoned`).
- `importPack` popularity bump wrapped so a synchronous throw can't reject the import.

## Deliberately deferred (pre-existing / larger scope — flagged, not fixed here)
- **`importCount` social-proof gaming** (`firestore.rules`): any signed-in user can bump unbounded with no dedupe. Proper fix is a per-uid receipt subcollection (rules + schema change) — out of scope for this PR.
- **Room lifecycle analytics remount overcounting**: no durable session key, so a hard refresh drops abandon events. Funnel-only; needs a session-key design.
- **Pre-existing board-unit confusion** in `invalidBoard` / `usePrivateRoomMonitor` / `useSendSettings` (compare `tiles.length` (n+2) to `roomTileCount` (n)). Predates this review range (before `e6cbe8e3`); touching it risks private-room board validation. Left as-is.

## Testing
- `npm run type-check` clean; `npx eslint src/` 0 errors; `npm run test:failures` → 1466 passed.
- New tests: composite-key routing (mixed online+local payload), `valueConflict` vs `duplicate`, `spiceBand` returns real values for sparse ladders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import/export now handles group variants more accurately across locale and game mode, reducing mismatches.
  * Pack imports now show success and error toasts so results are clearer.
  * Game settings can now report completion after a successful save.

* **Bug Fixes**
  * Fixed room and board size handling so content tile counts exclude start/finish tiles.
  * Improved intensity selection and extension limits for custom groups.
  * Prevented duplicate tile entries during pack creation and improved import conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->