### PR TITLE
fix(packs): remove redundant gameMode and locale chips from directory cards

### DIFF
--- a/src/views/CustomTileDialog/PackDirectory/index.tsx
+++ b/src/views/CustomTileDialog/PackDirectory/index.tsx
@@ -164,11 +164,7 @@ export default function PackDirectory({
                         {t('packs.by')} {pack.authorName}
                       </Typography>
                     )}
-                    <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', my: 0.75 }}>
-                      <Chip size="small" label={t(`gameMode.${pack.gameMode}`)} />
-                      <Chip size="small" label={pack.locale} />
-                    </Box>
-                    <Typography variant="body2" color="text.secondary">
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.75 }}>
                       {t('packs.summary', { groups: pack.groupCount, tiles: pack.tileCount })}
                       {pack.extensionCount > 0 &&
                         ` · ${t('packs.extensionSummary', { count: pack.extensionCount })}`}


### PR DESCRIPTION
## Summary
- Remove the gameMode and locale chips from each pack card in the public directory
- Game mode is already selected via the filter chips above the list, and locale is implicit from the app setting, so both chips were redundant noise on every card

## Testing
- `npm run type-check` clean
- `npx eslint` clean on changed file
- Full suite: 1526 tests pass (no tests referenced the removed chips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)