### PR TITLE
fix: allow importing any board size in public rooms from chat

### DIFF
--- a/src/components/MessageList/Message/index.test.tsx
+++ b/src/components/MessageList/Message/index.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@/test-utils';
+import { Timestamp } from 'firebase/firestore';
+import Message from './index';
+import type { Message as MessageType } from '@/types/Message';
+
+function settingsMessage(boardSize: number): MessageType {
+  return {
+    id: 'm1',
+    type: 'settings',
+    uid: 'author-1',
+    displayName: 'Author',
+    text: 'shared a board',
+    timestamp: { toDate: () => new Date(0) } as Timestamp,
+    boardSize,
+    gameBoardId: 'board-abc',
+    gameMode: 'online',
+  };
+}
+
+// The import / incompatible controls live inside the details popover, which
+// opens when the info button is clicked.
+function renderAndOpenDetails(message: MessageType, currentGameBoardSize: number, room: string) {
+  render(
+    <Message
+      message={message}
+      isOwnMessage={false}
+      currentGameBoardSize={currentGameBoardSize}
+      room={room}
+    />
+  );
+  fireEvent.click(screen.getByTestId('details-button-m1'));
+}
+
+// The import button is an anchor linking to ?importBoard=…; the incompatible
+// state renders no such link. (Trans text is empty here — i18n resources are
+// not loaded in unit tests — so assert on the link, not the label.)
+const importLink = () => document.querySelector('a[href*="importBoard"]');
+
+describe('Message settings import compatibility', () => {
+  it('offers import for a mismatched board in a public room', () => {
+    renderAndOpenDetails(settingsMessage(40), 60, 'PUBLIC');
+
+    expect(importLink()).toBeTruthy();
+  });
+
+  it('rejects a mismatched board in a private room', () => {
+    renderAndOpenDetails(settingsMessage(40), 60, 'my-private-room');
+
+    expect(importLink()).toBeNull();
+  });
+
+  it('offers import for a matching board in a private room', () => {
+    renderAndOpenDetails(settingsMessage(60), 60, 'my-private-room');
+
+    expect(importLink()).toBeTruthy();
+  });
+});

--- a/src/components/MessageList/Message/index.tsx
+++ b/src/components/MessageList/Message/index.tsx
@@ -6,6 +6,7 @@ import ScheduleIcon from '@mui/icons-material/Schedule';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { Trans, useTranslation } from 'react-i18next';
 import { generateSystemSummary, isSystemMessageLikelyToWrap } from '@/utils/messageUtils';
+import { isPublicRoom } from '@/helpers/strings';
 import { useCallback, useMemo, useState } from 'react';
 
 import ActionText from './actionText';
@@ -83,7 +84,10 @@ export default function Message({
     gameBoardId = message.gameBoardId;
   }
 
-  const isImportable = message.type === 'settings' && boardSize === currentGameBoardSize;
+  // Public rooms adopt the imported board's size (see useUrlImport), so any
+  // shared board is importable there. Private rooms still require a size match.
+  const isImportable =
+    message.type === 'settings' && (isPublicRoom(room) || boardSize === currentGameBoardSize);
 
   // Memoize import board URL construction
   const importBoardUrl = useMemo(() => {


### PR DESCRIPTION
## Problem

Users in the **public room** hit an "Incompatible board" error when trying to import a board shared by another player.

PR #1107 made public rooms accept any board size, but only updated the **send** gate (`useSendSettings.ts` — `isCompatibleBoard`). The **display** gate in the message list was missed: it still required a shared board's size to equal the current board size before showing the import button, otherwise rendering "Incompatible board".

Result: sending your own board worked, but importing someone else's shared board in public did not — which is what users reported.

## Fix

`src/components/MessageList/Message/index.tsx` — mirror the public-room escape hatch in the display gate:

```ts
const isImportable =
  message.type === 'settings' && (isPublicRoom(room) || boardSize === currentGameBoardSize);
```

The import flow already adopts the imported board's size (`useUrlImport.ts:90`), so mismatched-size import works end-to-end. Private rooms are unchanged — still require a size match.

## Tests

New `Message/index.test.tsx` (3 cases):
- public room, mismatched size → import offered
- private room, mismatched size → blocked (incompatible)
- private room, matching size → import offered

Verified the public-room test fails without the fix.

`npm run type-check` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings messages can now offer an import option in public rooms even when board sizes don’t match, making imports more flexible.

* **Bug Fixes**
  * Improved import compatibility checks so private rooms still require matching board sizes, while public rooms can proceed in more cases.

* **Tests**
  * Added coverage for public and private room scenarios to verify when the import option appears or stays hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->