### PR TITLE
fix(audio): swallow iOS InvalidStateError on audio start

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -50,6 +50,15 @@ if (typeof window !== 'undefined' && !window.importShim) {
         logger.warn('Dynamic import/method resolution failed:', { message: errorMsg, reason });
         event.preventDefault(); // Prevent the error from showing in console as unhandled
       }
+
+      // iOS Safari rejects Web Audio resume()/start() with InvalidStateError
+      // ("Failed to start the audio device") when the audio session is in a
+      // silent/interrupted state. Benign — playback silently skips. Howler
+      // (via use-sound) resumes the AudioContext in a detached promise, so this
+      // rejection can't be caught at the call site.
+      if (errorMsg.includes('Failed to start the audio device')) {
+        event.preventDefault();
+      }
     }
   });
 }

--- a/src/services/__tests__/ambientMusic.test.ts
+++ b/src/services/__tests__/ambientMusic.test.ts
@@ -112,6 +112,18 @@ describe('AmbientMusicService', () => {
     const { ambientMusic } = await import('../ambientMusic');
     expect(() => ambientMusic.stop()).not.toThrow();
   });
+
+  // iOS Safari throws InvalidStateError ("Failed to start the audio device")
+  // from sourceNode.start(); play() must swallow it, not reject.
+  it('play should not reject when start throws InvalidStateError', async () => {
+    mockSourceNode.start.mockImplementationOnce(() => {
+      throw new DOMException('Failed to start the audio device', 'InvalidStateError');
+    });
+
+    const { ambientMusic } = await import('../ambientMusic');
+    await expect(ambientMusic.play('lounge', 0.3)).resolves.toBeUndefined();
+    expect(ambientMusic.getIsPlaying()).toBe(false);
+  });
 });
 
 describe('useAmbientMusic hook', () => {

--- a/src/services/ambientMusic.ts
+++ b/src/services/ambientMusic.ts
@@ -52,18 +52,24 @@ class AmbientMusicService {
     const buffer = await this.loadSoundscape(soundscape);
     if (!buffer) return;
 
-    this.gainNode = ctx.createGain();
-    this.gainNode.gain.value = volume;
-    this.gainNode.connect(ctx.destination);
+    try {
+      this.gainNode = ctx.createGain();
+      this.gainNode.gain.value = volume;
+      this.gainNode.connect(ctx.destination);
 
-    this.sourceNode = ctx.createBufferSource();
-    this.sourceNode.buffer = buffer;
-    this.sourceNode.loop = true;
-    this.sourceNode.connect(this.gainNode);
-    this.sourceNode.start(0);
+      this.sourceNode = ctx.createBufferSource();
+      this.sourceNode.buffer = buffer;
+      this.sourceNode.loop = true;
+      this.sourceNode.connect(this.gainNode);
+      // iOS Safari can throw InvalidStateError ("Failed to start the audio
+      // device") when the audio session can't start (silent mode / interrupted).
+      this.sourceNode.start(0);
 
-    this.currentSoundscape = soundscape;
-    this.isPlaying = true;
+      this.currentSoundscape = soundscape;
+      this.isPlaying = true;
+    } catch {
+      this.stop();
+    }
   }
 
   stop(): void {
@@ -112,7 +118,7 @@ export function useAmbientMusic() {
 
   useEffect(() => {
     if (ambientMusicEnabled && effectiveSoundscape) {
-      ambientMusic.play(effectiveSoundscape, effectiveVolume);
+      ambientMusic.play(effectiveSoundscape, effectiveVolume).catch(() => {});
     } else {
       ambientMusic.stop();
     }


### PR DESCRIPTION
## Problem

Sentry: `InvalidStateError: Failed to start the audio device` — unhandled promise rejection on iOS Safari (26.5 / iOS 18.7), mechanism `onunhandledrejection`. Breadcrumb shows a **Roll** click before the throw.

iOS Safari rejects Web Audio `resume()`/`start()` with this error when the audio session is in a silent/interrupted state (silent switch, another app holding audio, session interruption). It's benign — playback just silently skips.

## Root cause

- **Primary (Roll path):** Howler (via `use-sound`) resumes the shared `AudioContext` in a **detached** `resume().then()` (`howler.core.js:525`, no `.catch()`). Reached through fire-and-forget `use-sound` calls (`useSoundAndDialog`, `useCardSound`). The rejection is not attached to any promise we hold, so it can't be caught at the call site.
- **Secondary:** `ambientMusic.play()` — `sourceNode.start(0)` unguarded, and called fire-and-forget from a `useEffect` with no `.catch()`.

## Fix

1. **Global handler** (`src/index.jsx`) — extend the existing `unhandledrejection` handler to `preventDefault()` the benign `"Failed to start the audio device"` rejection. Only reachable fix for the detached Howler reject.
2. **`ambientMusic.play()`** — wrap node build + `start(0)` in try/catch (cleanup via `stop()`); `.catch()` the fire-and-forget call in the `useEffect`.
3. **Regression test** — `play()` resolves (not rejects) when `start()` throws `InvalidStateError`.

## Verification

- `npm run type-check` clean
- `eslint` clean on changed files
- `ambientMusic` tests: 12 pass (incl. new regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)