### PR TITLE
fix(sentry): stop dropping all stack-traced errors in production

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -142,10 +142,13 @@ export function initializeSentry(): void {
         createRoutesFromChildren,
         matchRoutes,
       }),
-      // Filter out third-party errors (browser extensions, injected scripts)
+      // Filter out third-party errors (browser extensions, injected scripts).
+      // filterKeys must match applicationKey in sentryVitePlugin (vite.config.ts).
+      // 'exclusively' so app errors surfacing through third-party frames
+      // (gtag callbacks, extension wrappers) still get reported.
       Sentry.thirdPartyErrorFilterIntegration({
-        filterKeys: ['blitzed-out'], // Add your app identifier
-        behaviour: 'drop-error-if-contains-third-party-frames',
+        filterKeys: ['blitzed-out'],
+        behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
       }),
     ],
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,10 @@ export default defineConfig({
           sentryVitePlugin({
             org: 'blitzedout',
             project: 'javascript-react',
+            // Injects module metadata so thirdPartyErrorFilterIntegration can
+            // tell app frames from third-party frames. Without it, every frame
+            // looks third-party and all stack-traced errors get dropped.
+            applicationKey: 'blitzed-out',
           }),
         ]
       : []),


### PR DESCRIPTION
## Problem

Production Sentry has silently dropped **every error event that has a stack trace** since #864 (Nov 2025).

`thirdPartyErrorFilterIntegration` in `src/services/sentry.ts` was configured with `filterKeys: ['blitzed-out']`, but `sentryVitePlugin` in `vite.config.ts` never set `applicationKey`. That option is what injects `_sentryModuleMetadata` into the bundles; without it, the SDK treats every frame as third-party. Combined with `behaviour: 'drop-error-if-contains-third-party-frames'` (drop if *any* frame is third-party), all framed events were dropped. Only stackless noise got through — which is how this surfaced: Sentry issue 7593572048 ("Error: Aa", a gtag.js-internal rejection with no stack) was one of the few events still arriving.

Verified against the live production bundles: zero injected `_sentryModuleMetadata` (only the SDK's reader code references it).

## Fix

- **vite.config.ts** — add `applicationKey: 'blitzed-out'` to `sentryVitePlugin` so builds carry app-frame metadata (matches `filterKeys`).
- **src/services/sentry.ts** — switch behaviour to `'drop-error-if-exclusively-contains-third-party-frames'`, so app errors whose stacks pass through gtag callbacks or extension wrappers still report; pure third-party errors (extensions, injected scripts) are still dropped.

## Verification

- `npm run type-check` clean
- `npx eslint` clean on changed files
- `npm run test:failures` — 1532 passed
- Post-deploy check: confirm new events in Sentry carry stack traces and app frames resolve via sourcemaps (`SENTRY_UPLOAD_SOURCEMAPS=true` builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)