### PR TITLE
feat(settings): align sticky header with page column, group manage custom actions

### DIFF
--- a/src/views/GameSettings/components/JumpNav.tsx
+++ b/src/views/GameSettings/components/JumpNav.tsx
@@ -1,4 +1,12 @@
-import { Box, Chip, List, ListItemButton, ListItemText, ListSubheader } from '@mui/material';
+import {
+  Box,
+  Chip,
+  Container,
+  List,
+  ListItemButton,
+  ListItemText,
+  ListSubheader,
+} from '@mui/material';
 import { JSX, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useBreakpoint from '@/hooks/useBreakpoint';
@@ -77,41 +85,34 @@ export default function JumpNav({ entries, onNavigate, railTop = 120 }: JumpNavP
 
   if (isMobile) {
     return (
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 0.75,
-          overflowX: 'auto',
-          py: 1,
-          px: 2,
-          bgcolor: 'background.paper',
-          borderBottom: 1,
-          borderColor: 'divider',
-          scrollbarWidth: 'none',
-        }}
-      >
-        {entries.map(({ id, labelKey, scope }) => (
-          <Chip
-            key={id}
-            label={t(labelKey)}
-            size="small"
-            onClick={() => navigate(id)}
-            variant={activeId === id ? 'filled' : 'outlined'}
-            sx={{ flexShrink: 0 }}
-            icon={
-              <Box
-                component="span"
-                sx={{
-                  width: 8,
-                  height: 8,
-                  borderRadius: '50%',
-                  bgcolor: SCOPE_COLORS[scope],
-                  ml: 1,
-                }}
-              />
-            }
-          />
-        ))}
+      <Box sx={{ bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider' }}>
+        <Container
+          maxWidth="lg"
+          sx={{ display: 'flex', gap: 0.75, overflowX: 'auto', py: 1, scrollbarWidth: 'none' }}
+        >
+          {entries.map(({ id, labelKey, scope }) => (
+            <Chip
+              key={id}
+              label={t(labelKey)}
+              size="small"
+              onClick={() => navigate(id)}
+              variant={activeId === id ? 'filled' : 'outlined'}
+              sx={{ flexShrink: 0 }}
+              icon={
+                <Box
+                  component="span"
+                  sx={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    bgcolor: SCOPE_COLORS[scope],
+                    ml: 1,
+                  }}
+                />
+              }
+            />
+          ))}
+        </Container>
       </Box>
     );
   }

--- a/src/views/GameSettings/components/ModeBar.tsx
+++ b/src/views/GameSettings/components/ModeBar.tsx
@@ -1,4 +1,4 @@
-import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { Box, Container, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { isPublicRoom } from '@/helpers/strings';
 import { GameMode, Settings } from '@/types/Settings';
@@ -44,42 +44,35 @@ export default function ModeBar({
   };
 
   return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 2,
-        flexWrap: 'wrap',
-        py: 1,
-        px: { xs: 2, sm: 3 },
-        bgcolor: 'background.paper',
-        borderBottom: 1,
-        borderColor: 'divider',
-      }}
-    >
-      <Typography
-        variant="overline"
-        sx={{ color: 'text.secondary', lineHeight: 1, letterSpacing: '0.1em' }}
+    <Box sx={{ bgcolor: 'background.paper', borderBottom: 1, borderColor: 'divider' }}>
+      <Container
+        maxWidth="lg"
+        sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap', py: 1 }}
       >
-        {t('playing')}
-      </Typography>
-      <ToggleButtonGroup
-        value={formData.gameMode}
-        exclusive
-        size="small"
-        onChange={applyMode}
-        aria-label={t('playing')}
-      >
-        <ToggleButton value="solo">{t('solo')}</ToggleButton>
-        <ToggleButton value="online">{t('playStyleWithOthers')}</ToggleButton>
-        <ToggleButton value="local">{t('playStyleSharedDevice')}</ToggleButton>
-      </ToggleButtonGroup>
-      <Typography
-        variant="caption"
-        sx={{ color: 'text.secondary', display: { xs: 'none', md: 'block' } }}
-      >
-        {t('modeBarHint')}
-      </Typography>
+        <Typography
+          variant="overline"
+          sx={{ color: 'text.secondary', lineHeight: 1, letterSpacing: '0.1em' }}
+        >
+          {t('playing')}
+        </Typography>
+        <ToggleButtonGroup
+          value={formData.gameMode}
+          exclusive
+          size="small"
+          onChange={applyMode}
+          aria-label={t('playing')}
+        >
+          <ToggleButton value="solo">{t('solo')}</ToggleButton>
+          <ToggleButton value="online">{t('playStyleWithOthers')}</ToggleButton>
+          <ToggleButton value="local">{t('playStyleSharedDevice')}</ToggleButton>
+        </ToggleButtonGroup>
+        <Typography
+          variant="caption"
+          sx={{ color: 'text.secondary', display: { xs: 'none', md: 'block' } }}
+        >
+          {t('modeBarHint')}
+        </Typography>
+      </Container>
     </Box>
   );
 }

--- a/src/views/GameSettings/index.tsx
+++ b/src/views/GameSettings/index.tsx
@@ -203,7 +203,7 @@ export default function GameSettings(): JSX.Element {
           borderColor: 'divider',
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: { xs: 1, sm: 2 }, py: 1 }}>
+        <Container maxWidth="lg" sx={{ display: 'flex', alignItems: 'center', gap: 1.5, py: 1 }}>
           <IconButton onClick={returnToRoom} aria-label={t('back', 'Back')}>
             <ArrowBackIcon />
           </IconButton>
@@ -227,7 +227,7 @@ export default function GameSettings(): JSX.Element {
           >
             <Trans i18nKey={isSubmitting ? 'buildingBoard' : 'update'} />
           </Button>
-        </Box>
+        </Container>
         <ModeBar formData={formData} setFormData={setFormData} getPrivateRoom={getPrivateRoom} />
         {isMobile && <JumpNav entries={SECTIONS} onNavigate={handleNavigate} />}
       </Box>
@@ -316,6 +316,7 @@ export default function GameSettings(): JSX.Element {
                 actionsList={actionsList}
                 pickerOpen={actionsPickerOpen}
                 onPickerOpenChange={setActionsPickerOpen}
+                onManageCustomTiles={() => setOpenCustomTile(true)}
               />
             </SettingsSection>
 
@@ -353,18 +354,7 @@ export default function GameSettings(): JSX.Element {
               />
             </SettingsSection>
 
-            <Box
-              sx={{
-                display: 'flex',
-                gap: 1,
-                mt: 3,
-                flexDirection: { xs: 'column', sm: 'row' },
-                justifyContent: 'space-between',
-              }}
-            >
-              <Button variant="outlined" type="button" onClick={() => setOpenCustomTile(true)}>
-                <Trans i18nKey="customTilesLabel" />
-              </Button>
+            <Box sx={{ display: 'flex', mt: 3, justifyContent: 'flex-end' }}>
               <Button
                 variant="contained"
                 type="submit"

--- a/src/views/GameSettings/sections/ActionsSection.tsx
+++ b/src/views/GameSettings/sections/ActionsSection.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
+import EditIcon from '@mui/icons-material/Edit';
 import { JSX, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -28,6 +29,8 @@ interface ActionsSectionProps {
   /** Picker visibility is lifted so the page header's "+ Add" can open it too. */
   pickerOpen: boolean;
   onPickerOpenChange: (open: boolean) => void;
+  /** Opens the custom-tile manager; the dialog lives on the settings page. */
+  onManageCustomTiles: () => void;
 }
 
 /**
@@ -41,6 +44,7 @@ export default function ActionsSection({
   actionsList,
   pickerOpen,
   onPickerOpenChange,
+  onManageCustomTiles,
 }: ActionsSectionProps): JSX.Element {
   const { t } = useTranslation();
   const [removed, setRemoved] = useState<{ key: string; entry: ActionEntry } | null>(null);
@@ -183,21 +187,31 @@ export default function ActionsSection({
         );
       })}
 
-      <Button
-        fullWidth
-        startIcon={<AddIcon />}
-        onClick={() => onPickerOpenChange(true)}
-        sx={{
-          border: '1px dashed',
-          borderColor: 'primary.main',
-          borderRadius: 2,
-          py: 1.1,
-          opacity: 0.9,
-        }}
-      >
-        {t('addActions')}
-        {catalogRemaining > 0 && ` · ${t('moreAvailable', { count: catalogRemaining })}`}
-      </Button>
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: { xs: 'wrap', sm: 'nowrap' } }}>
+        <Button
+          startIcon={<AddIcon />}
+          onClick={() => onPickerOpenChange(true)}
+          sx={{
+            flex: 1,
+            border: '1px dashed',
+            borderColor: 'primary.main',
+            borderRadius: 2,
+            py: 1.1,
+            opacity: 0.9,
+          }}
+        >
+          {t('addActions')}
+          {catalogRemaining > 0 && ` · ${t('moreAvailable', { count: catalogRemaining })}`}
+        </Button>
+        <Button
+          variant="outlined"
+          startIcon={<EditIcon />}
+          onClick={onManageCustomTiles}
+          sx={{ flexShrink: 0 }}
+        >
+          {t('customTilesLabel')}
+        </Button>
+      </Box>
 
       <FinishRangeRow formData={formData} setFormData={setFormData} />
       <WarningAlert formData={formData} />

--- a/src/views/GameSettings/sections/__tests__/ActionsSection.test.tsx
+++ b/src/views/GameSettings/sections/__tests__/ActionsSection.test.tsx
@@ -171,6 +171,20 @@ describe('ActionsSection (loadout)', () => {
     expect(setFormData.mock.calls[0][0].soloPlay).toBe(true);
   });
 
+  it('the manage custom actions button invokes onManageCustomTiles', async () => {
+    const onManageCustomTiles = vi.fn();
+    render(
+      <Harness
+        formData={makeFormData({})}
+        setFormData={setFormData}
+        actionsList={ACTIONS_LIST}
+        onManageCustomTiles={onManageCustomTiles}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /customTilesLabel/ }));
+    expect(onManageCustomTiles).toHaveBeenCalledTimes(1);
+  });
+
   it('marks an enabled group unavailable when the mode no longer offers it', () => {
     render(
       <Harness

--- a/src/views/GameSettings/sections/__tests__/ActionsSection.test.tsx
+++ b/src/views/GameSettings/sections/__tests__/ActionsSection.test.tsx
@@ -7,11 +7,21 @@ import { useState } from 'react';
 import ActionsSection from '../ActionsSection';
 import type { Settings } from '@/types/Settings';
 
-type HarnessProps = Omit<Parameters<typeof ActionsSection>[0], 'pickerOpen' | 'onPickerOpenChange'>;
+type HarnessProps = Omit<
+  Parameters<typeof ActionsSection>[0],
+  'pickerOpen' | 'onPickerOpenChange' | 'onManageCustomTiles'
+> & { onManageCustomTiles?: () => void };
 
-function Harness(props: HarnessProps) {
+function Harness({ onManageCustomTiles = () => {}, ...props }: HarnessProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
-  return <ActionsSection {...props} pickerOpen={pickerOpen} onPickerOpenChange={setPickerOpen} />;
+  return (
+    <ActionsSection
+      {...props}
+      pickerOpen={pickerOpen}
+      onPickerOpenChange={setPickerOpen}
+      onManageCustomTiles={onManageCustomTiles}
+    />
+  );
 }
 
 vi.mock('react-i18next', () => ({


### PR DESCRIPTION
## What

Two advanced-settings (`/:id/settings`) polish fixes.

**1. Sticky header alignment.** The title bar, mode bar, and mobile jump-nav rendered full-width while the page body is a centered `Container maxWidth="lg"` column — so their contents hugged the viewport edges, misaligned with the body. Now each sticky row's contents sit in the same `maxWidth="lg"` Container. The full-width bands (background + bottom border) are preserved.

**2. "Manage custom actions" placement.** The button previously sat orphaned in the page's bottom row next to Update. Moved into the Actions section, side-by-side with the dashed Add button. The `CustomTileDialog` stays on the page and is opened via a new `onManageCustomTiles` prop on `ActionsSection`. Bottom row is now just the right-aligned Update button.

## Changed files

- `src/views/GameSettings/index.tsx` — title bar → Container; wire `onManageCustomTiles`; simplify bottom row
- `src/views/GameSettings/components/ModeBar.tsx` — full-width band, contents in Container
- `src/views/GameSettings/components/JumpNav.tsx` — mobile chip row same pattern
- `src/views/GameSettings/sections/ActionsSection.tsx` — new `onManageCustomTiles` prop + side-by-side Add / Manage row
- `src/views/GameSettings/sections/__tests__/ActionsSection.test.tsx` — harness supplies the new required prop

## Verification

type-check ✓ · eslint ✓ · 150 GameSettings tests ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated way to manage custom tiles directly from Game Settings.
  * Updated the actions area to show both “Add actions” and “Custom tiles” buttons.

* **UI Improvements**
  * Refined the Game Settings header and navigation layout for a cleaner, more consistent experience.
  * Improved mobile layout for quicker access to game settings sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->