### PR TITLE
fix(tests): fail CI on unexpected console.error

### DIFF
--- a/src/components/CastButton/__tests__/CastButton.test.tsx
+++ b/src/components/CastButton/__tests__/CastButton.test.tsx
@@ -71,6 +71,7 @@ const TestWrapper = ({ children }: { children: React.ReactNode }) => (
 describe('CastButton Core Functionality', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRequestSession.mockResolvedValue({});
     window.__castApiInitialized = true;
   });
 

--- a/src/services/__tests__/contentPacks.test.ts
+++ b/src/services/__tests__/contentPacks.test.ts
@@ -218,8 +218,10 @@ describe('contentPacks service', () => {
   });
 
   it('parsePack returns undefined on invalid JSON', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const bad = { contents: 'not json' } as ContentPackDoc;
     expect(parsePack(bad)).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
   });
 
   describe('listMyPacks', () => {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -36,7 +36,13 @@ const originalLog = console.log;
 const originalWarn = console.warn;
 const originalDebug = console.debug;
 
+// Unexpected (non-suppressed) console.error calls from the test currently running.
+// Populated by the console.error override below, checked and cleared in afterEach.
+let unexpectedErrors: any[][] = [];
+
 beforeEach(() => {
+  unexpectedErrors = [];
+
   // Suppress all console.log in tests to reduce noise
   console.log = vi.fn();
 
@@ -68,10 +74,14 @@ beforeEach(() => {
   ];
   console.error = (...args: any[]) => {
     const msg = typeof args[0] === 'string' ? args[0] : '';
+    originalError.call(console, ...args);
     if (SUPPRESSED_ERROR_FRAGMENTS.some((fragment) => msg.includes(fragment))) {
       return;
     }
-    originalError.call(console, ...args);
+    // Tests that expect an error path should assert on it via a local
+    // `vi.spyOn(console, 'error').mockImplementation(...)`, which replaces
+    // this override for the duration of that test.
+    unexpectedErrors.push(args);
   };
 });
 
@@ -578,4 +588,11 @@ afterEach(() => {
 
   // Note: IndexedDB cleanup removed to prevent conflicts during parallel test execution
   // Each test that uses IndexedDB should handle its own cleanup or use mocks
+
+  // Fail the test if it logged an unexpected console.error. Expected-error
+  // paths should assert via a local `vi.spyOn(console, 'error')`.
+  if (unexpectedErrors.length > 0) {
+    const messages = unexpectedErrors.map((args) => args.map(String).join(' ')).join('\n');
+    throw new Error(`Unexpected console.error call(s) during test:\n${messages}`);
+  }
 });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -74,10 +74,10 @@ beforeEach(() => {
   ];
   console.error = (...args: any[]) => {
     const msg = typeof args[0] === 'string' ? args[0] : '';
-    originalError.call(console, ...args);
     if (SUPPRESSED_ERROR_FRAGMENTS.some((fragment) => msg.includes(fragment))) {
       return;
     }
+    originalError.call(console, ...args);
     // Tests that expect an error path should assert on it via a local
     // `vi.spyOn(console, 'error').mockImplementation(...)`, which replaces
     // this override for the duration of that test.

--- a/src/stores/__tests__/contentLibrary.test.ts
+++ b/src/stores/__tests__/contentLibrary.test.ts
@@ -215,6 +215,7 @@ describe('contentLibrary', () => {
     });
 
     it('rolls back the tile deletes when the group delete fails mid-transaction', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const id = await addCustomGroup(buildGroup());
       await seedTile(id!);
       await seedTile(id!, { action: 'Another action' });
@@ -229,6 +230,7 @@ describe('contentLibrary', () => {
       } finally {
         db.customGroups.hook('deleting').unsubscribe(boom);
       }
+      expect(errorSpy).toHaveBeenCalled();
 
       expect(await db.customGroups.get(id!)).toBeDefined();
       expect(await db.customTiles.where('group_id').equals(id!).count()).toBe(2);


### PR DESCRIPTION
## Summary
- CI logged 3 stderr error blocks even though all tests passed — nothing was actually asserting on them.
- `setupTests.ts` suppressed known-noisy `console.error` fragments and silently reprinted anything else. Now unexpected (non-suppressed) calls are collected per-test and thrown in `afterEach`, failing the test.
- `CastButton.test.tsx`: real bug — `mockRequestSession.mockResolvedValue({})` was set once at module load, but the global `mockReset` config (`vitest.ci.config.ts`) wipes mock implementations before every test, so `requestSession()` returned `undefined` and the `.catch()` in `CastButton/index.tsx:211` threw `TypeError: Cannot read properties of undefined (reading 'catch')`. Fixed by re-applying the resolved value in `beforeEach`.
- `contentLibrary.test.ts` / `contentPacks.test.ts`: these two tests intentionally exercise error-logging code paths (rollback-on-failure, invalid-JSON parsing). They now use a local `vi.spyOn(console, 'error')` instead of relying on the global suppression list, so the new gate doesn't have to carry permanent holes for them.

## Test plan
- [x] `npm run type-check`
- [x] `npx eslint` on changed files
- [x] `npm run test:ci` — 137 files / 1572 tests passed, zero unexpected stderr blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for expected error logging during invalid content parsing and failed group deletion.
  * Added stricter detection of unexpected console errors during test execution.
  * Standardized session request mock behavior for more consistent test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->