### PR TITLE
fix(chat): single info icon on settings/room system messages

### DIFF
--- a/src/components/MessageList/Message/index.tsx
+++ b/src/components/MessageList/Message/index.tsx
@@ -1,9 +1,7 @@
 import { DEFAULT_TILE_COUNT } from '@/constants/boardConstants';
 import { Box, Button, Chip, IconButton, Popover, Typography } from '@mui/material';
-import HomeIcon from '@mui/icons-material/Home';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ScheduleIcon from '@mui/icons-material/Schedule';
-import SettingsIcon from '@mui/icons-material/Settings';
 import { Trans, useTranslation } from 'react-i18next';
 import { generateSystemSummary, isSystemMessageLikelyToWrap } from '@/utils/messageUtils';
 import { isPublicRoom } from '@/helpers/strings';
@@ -193,16 +191,14 @@ export default function Message({
         data-testid={`message-${id}`}
       >
         <Box component="div" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Box
-            component="span"
-            sx={{ display: 'flex', alignItems: 'center', color: 'text.secondary' }}
+          <IconButton
+            size="small"
+            onClick={handleDetailsClick}
+            aria-label="View details"
+            data-testid={`details-button-${id}`}
           >
-            {message.type === 'settings' ? (
-              <SettingsIcon fontSize="small" />
-            ) : (
-              <HomeIcon fontSize="small" />
-            )}
-          </Box>
+            <InfoOutlinedIcon fontSize="small" />
+          </IconButton>
           <Box sx={{ flex: 1, minWidth: 0, ml: 0.5 }}>
             <Typography variant="body2" component="span" sx={{ lineHeight: 1.2 }}>
               <strong>{displayName}</strong> {systemSummary}
@@ -219,14 +215,6 @@ export default function Message({
               {ago}
             </Typography>
           </Box>
-          <IconButton
-            size="small"
-            onClick={handleDetailsClick}
-            aria-label="View details"
-            data-testid={`details-button-${id}`}
-          >
-            <InfoOutlinedIcon fontSize="small" />
-          </IconButton>
         </Box>
         {/* Details Popover */}
         <Popover


### PR DESCRIPTION
## Summary

Settings/room system messages in the chat rendered two icons: a leading cog (`settings`) or house (`room`) icon, and a trailing info button that opens the details popover.

This removes the leading cog/house icon and moves the info button into that leading position, so each system message has a single control.

## Changes

- `src/components/MessageList/Message/index.tsx` — deleted the leading icon `Box` and its `SettingsIcon`/`HomeIcon` branch, relocated the details `IconButton` to the start of the row, dropped the now-unused imports.

## Verification

- `src/components/MessageList/Message/index.test.tsx` — 5/5 pass (the details-button test still resolves via `data-testid`, unchanged).
- `eslint src/components/MessageList/` — 0 errors.
- `type-check` — no errors in the touched file. Unrelated pre-existing `syncService` errors from another in-flight refactor are present in the working tree but are not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated system-message headers to use a consistent information button for viewing details.
  * Repositioned the details button alongside the header icons for easier access.
  * Removed type-specific icons from system-message headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->