### PR TITLE
fix(chat): tighten leading gap on system messages

### DIFF
--- a/src/components/MessageList/Message/index.tsx
+++ b/src/components/MessageList/Message/index.tsx
@@ -199,7 +199,7 @@ export default function Message({
           >
             <InfoOutlinedIcon fontSize="small" />
           </IconButton>
-          <Box sx={{ flex: 1, minWidth: 0, ml: 0.5 }}>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
             <Typography variant="body2" component="span" sx={{ lineHeight: 1.2 }}>
               <strong>{displayName}</strong> {systemSummary}
             </Typography>


### PR DESCRIPTION
## Summary

Follow-up to #1136, which merged before this commit landed on the branch.

#1136 replaced the leading cog/house icon on settings/room system messages with the details `IconButton`. `IconButton` carries its own padding, so the text column's leftover `ml: 0.5` — on top of the row's `gap: 0.5` — left a wider leading gap than the old bare-icon layout. This drops that margin.

## Changes

- `src/components/MessageList/Message/index.tsx` — removed `ml: 0.5` from the system-message text column.

## Verification

- `src/components/MessageList/Message/index.test.tsx` — 5/5 pass.
- Spacing not visually verified in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)