### PR TITLE
refactor(sync): the remote user-data document gets an owner

### DIFF
--- a/docs/engineering/data-and-sync.md
+++ b/docs/engineering/data-and-sync.md
@@ -53,22 +53,26 @@ Security rules for each are documented in [security.md](security.md).
 
 ## Sync engine
 
-Per-entity sync under `src/services/sync/`, coordinated by `syncOrchestrator.ts`. The orchestrator reads/writes the per-user Firestore document `user-data/{uid}` and runs entity syncs in parallel:
+**The `user-data/{uid}` document has one owner: `src/services/sync/remoteUserData.ts`.** It is the only module that knows the document's field names, its dual legacy/V2 disabled-defaults encoding, and its size caps; it exposes `readRemoteUserData` (one `getDoc`, decoded into the app's own vocabulary), `collectLocalUserData` (this device's whole snapshot), and `writeRemoteUserData` (one `setDoc` merge). A section decoded as `undefined` means the document does not carry it, which the merges must not confuse with "present but emptied".
 
-- `CustomTilesSync` — merges local and cloud tiles using `TileMatcher` (key = `group_id|intensity|action`); writes the merged set back. `forceSync` replaces local with cloud.
+One cycle = **one read, then one write if anything changed** (`syncOrchestrator.ts`). Entity merges report `changed` rather than pushing themselves — a push per entity used to race the other merges, publish a half-merged document, and echo back through the real-time listener. `gameBoards` is omitted from a write when this device has none, so a board-less device cannot blank another's.
+
+Per-entity merge policy lives under `src/services/sync/`, and the orchestrator runs the merges in parallel:
+
+- `CustomTilesSync` — merges local and cloud tiles using `TileMatcher` (key = `group_id|intensity|action`). `forceSync` replaces local with cloud.
 - `CustomGroupsSync` — merges new groups by `(name, locale, gameMode)`.
-- `DisabledDefaultsSync` — merges the `disabledDefaults` table **per-record** with last-writer-wins (keyed by the content tuple). Re-enables propagate as `active: false` **tombstones**, so a re-enable on one device reaches the others (the old whole-list-replace could not). The historical 100-record corruption cap is gone; instead the push **bounds** the synced set with a loud warning and writes a legacy active-only `disabledDefaults` array (capped 100) alongside the new `disabledDefaultsV2` records for pre-V2 clients. Row `isEnabled` flags are reconciled from the table (`reconcileDisabledRows`).
+- `DisabledDefaultsSync` — merges the `disabledDefaults` table **per-record** with last-writer-wins (keyed by the content tuple). Re-enables propagate as `active: false` **tombstones**, so a re-enable on one device reaches the others (the old whole-list-replace could not). Row `isEnabled` flags are reconciled from the table (`reconcileDisabledRows`). The wire encoding is the owner's business: it writes a legacy active-only `disabledDefaults` array (capped 100) alongside the `disabledDefaultsV2` records for pre-V2 clients, bounds the record set at 1000 with a loud warning, and on read prefers V2 — up-converting a legacy-only document so the merge only ever sees records.
 - `GameBoardsSync` — upserts boards (keyed by title).
 - `SettingsSync` — merges settings into the store.
 
 - `CustomGroupExtensionsSync` — user-appended intensity levels on **default** groups travel as name/locale/gameMode-keyed deltas in a `customGroupExtensions` field (default groups never sync as whole records; each device seeds its own). Pull applies them with the append-only `appendIntensities` merge (`src/services/intensityMerge.ts`) — the same semantics the importer (`groupExtensions` in ExportData 2.1.0) and the locale re-seeder (`mergeSeedIntensities`, which preserves appended levels across `MIGRATION_VERSION` bumps) use. Append-only: removals don't propagate.
 
-Before merging, `syncService.ts` runs a duplicate-tile cleanup to undo a historical sync bug.
+Before merging, the orchestrator runs a duplicate-tile cleanup (`sync/localCleanup.ts`) to undo a historical sync bug. `syncService.ts` above all this decides only _when_ a cycle runs (login push, pull, periodic, real-time listener).
 
 **What triggers sync:**
 
 1. **Automatic** — Dexie write → middleware → debounced `requestSync()`.
-2. **Manual** — user-initiated sync from the auth/account UI.
+2. **Manual** — `syncData()` from the auth context (a full push). There is no conflict-preview flow: `intelligentSync`, which refused to sync whenever both sides were merely non-empty, had no UI consumer and was deleted — the LWW merges it bypassed are strictly better behaved.
 3. **Periodic** — optional ~5-minute interval.
 
 **Conditions:** sync only runs for authenticated, **non-anonymous** users. All cloud data is scoped to `user-data/{uid}` — no cross-user visibility there.
@@ -77,7 +81,7 @@ Before merging, `syncService.ts` runs a duplicate-tile cleanup to undo a histori
 
 **Real-time pull + last-writer-wins.** Non-anonymous sessions attach an `onSnapshot` listener to `user-data/{uid}` (`subscribeToUserData` in `syncService.ts`, wired in `useAuthSync`), so a change pushed from one device reflects on the others within seconds rather than waiting for the periodic/debounced cycle. Push stays debounced (~2 s). Conflicts resolve last-writer-wins via a per-record `updatedAt` (Unix ms) on custom tiles and game boards (`SyncBase.remoteWins`, strict `>`). The push remains debounced; the listener only pulls.
 
-Loop prevention (push→pull→apply→push) relies on three guards: the snapshot handler skips events with `metadata.hasPendingWrites` (our own writes); an apply-phase suppression flag in `syncMiddleware` (`beginSyncApply`/`endSyncApply`) stops sync-engine Dexie writes from scheduling an echo push; and the entity merges only push back when something actually changed.
+Loop prevention (push→pull→apply→push) relies on three guards: the snapshot handler skips events with `metadata.hasPendingWrites` (our own writes); an apply-phase suppression flag in `syncMiddleware` (`beginSyncApply`/`endSyncApply`) stops sync-engine Dexie writes from scheduling an echo push; and a cycle publishes only when a merge reported a change.
 
 **Stated limitations of the LWW/real-time model:**
 

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -25,7 +25,6 @@ export interface AuthContextType {
   logout: () => Promise<void>;
   wipeAllData: () => Promise<void>;
   syncData: () => Promise<boolean>;
-  intelligentSync: () => Promise<{ success: boolean; conflicts?: string[] }>;
   isAnonymous: boolean;
 }
 
@@ -46,7 +45,7 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
   // Track if initial auth check is complete
   const authInitializedRef = useRef<boolean>(false);
 
-  const { syncStatus, syncData, intelligentSync: handleIntelligentSync } = useAuthSync(user);
+  const { syncStatus, syncData } = useAuthSync(user);
 
   async function login(displayName = ''): Promise<User | null> {
     try {
@@ -279,7 +278,6 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
       logout: logoutUser,
       wipeAllData: wipeAllAppDataAndReload,
       syncData,
-      intelligentSync: handleIntelligentSync,
       isAnonymous: user?.isAnonymous || false,
     }),
     [
@@ -292,7 +290,6 @@ function AuthProvider(props: AuthProviderProps): JSX.Element {
       logoutUser,
       wipeAllAppDataAndReload,
       syncData,
-      handleIntelligentSync,
     ]
   );
 

--- a/src/hooks/__tests__/useAuthSync.test.ts
+++ b/src/hooks/__tests__/useAuthSync.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { User } from '@/types';
 import {
-  intelligentSync as intelligentSyncService,
   startPeriodicSync,
   stopPeriodicSync,
   syncAllDataToFirebase,
@@ -24,7 +23,6 @@ describe('useAuthSync', () => {
     vi.mocked(syncAllDataToFirebase).mockResolvedValue(true);
     vi.mocked(startPeriodicSync).mockReturnValue(true);
     vi.mocked(stopPeriodicSync).mockReturnValue(true);
-    vi.mocked(intelligentSyncService).mockResolvedValue({ success: true });
   });
 
   afterEach(() => {
@@ -128,30 +126,6 @@ describe('useAuthSync', () => {
 
     expect(returned!).toBe(false);
     expect(syncAllDataToFirebase).not.toHaveBeenCalled();
-  });
-
-  it('intelligentSync delegates to syncService and returns result', async () => {
-    const { result } = renderHook(() => useAuthSync(makeUser()));
-
-    let syncResult: { success: boolean; conflicts?: string[] };
-    await act(async () => {
-      syncResult = await result.current.intelligentSync();
-    });
-
-    expect(intelligentSyncService).toHaveBeenCalledTimes(1);
-    expect(syncResult!).toEqual({ success: true });
-  });
-
-  it('intelligentSync returns failure without calling service for null user', async () => {
-    const { result } = renderHook(() => useAuthSync(null));
-
-    let syncResult: { success: boolean; conflicts?: string[] };
-    await act(async () => {
-      syncResult = await result.current.intelligentSync();
-    });
-
-    expect(intelligentSyncService).not.toHaveBeenCalled();
-    expect(syncResult!.success).toBe(false);
   });
 
   it('stops sync and clears timers on unmount', async () => {

--- a/src/hooks/useAuthSync.ts
+++ b/src/hooks/useAuthSync.ts
@@ -38,25 +38,6 @@ export function useAuthSync(user: User | null) {
     return performSync(syncAllDataToFirebase);
   }, [performSync]);
 
-  const intelligentSync = useCallback(async (): Promise<{
-    success: boolean;
-    conflicts?: string[];
-  }> => {
-    if (!user || user.isAnonymous) {
-      return { success: false, conflicts: ['User not logged in or is anonymous'] };
-    }
-    try {
-      setSyncStatus((prev) => ({ syncing: true, lastSync: prev.lastSync }));
-      const { intelligentSync: runIntelligentSync } = await import('@/services/syncService');
-      const result = await runIntelligentSync();
-      setSyncStatus({ syncing: false, lastSync: new Date() });
-      return result;
-    } catch {
-      setSyncStatus((prev) => ({ syncing: false, lastSync: prev.lastSync }));
-      return { success: false, conflicts: ['Sync failed due to error'] };
-    }
-  }, [user]);
-
   // Start or stop sync lifecycle when user changes
   useEffect(() => {
     if (!user || user.isAnonymous) {
@@ -121,5 +102,5 @@ export function useAuthSync(user: User | null) {
     };
   }, [user]);
 
-  return { syncStatus, syncData, intelligentSync };
+  return { syncStatus, syncData };
 }

--- a/src/services/__tests__/syncService.test.ts
+++ b/src/services/__tests__/syncService.test.ts
@@ -11,8 +11,7 @@ import { deleteGroup } from '@/stores/contentLibrary';
 import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
 import {
   subscribeToUserData,
-  syncCustomGroupsToFirebase,
-  syncCustomTilesToFirebase,
+  syncAllDataToFirebase,
   syncDataFromFirebase,
 } from '@/services/syncService';
 
@@ -47,7 +46,6 @@ import {
   reconcileDisabledRows,
   getAllDisabledRecords,
 } from '@/stores/disabledDefaults';
-import { syncDisabledDefaultsToFirebase } from '@/services/syncService';
 
 describe('syncService', () => {
   const mockUser = { uid: 'test-user-123', isAnonymous: false };
@@ -81,43 +79,86 @@ describe('syncService', () => {
       id: 'test-user-123',
       path: 'user-data/test-user-123',
     } as any);
+
+    // One write per cycle means every push collects every section, so these
+    // sources must answer in all describes, not just the pull ones. Set them
+    // here rather than in the factory: the CI config resets mock
+    // implementations between tests.
+    vi.mocked(getTiles).mockResolvedValue([]);
+    vi.mocked(getCustomGroups).mockResolvedValue([]);
+    vi.mocked(setDoc).mockResolvedValue(undefined);
+    vi.mocked(getBoards).mockResolvedValue([]);
+    vi.mocked(getAllDisabledRecords).mockResolvedValue([]);
+    vi.mocked(mergeRemoteDisabledRecords).mockResolvedValue(0);
+    vi.mocked(reconcileDisabledRows).mockResolvedValue(undefined);
+    vi.mocked(useSettingsStore.getState).mockReturnValue({
+      settings: {},
+      updateSettings: vi.fn(),
+    } as any);
   });
 
   afterEach(() => {
     consoleErrorSpy?.mockRestore();
   });
 
-  describe('syncCustomTilesToFirebase', () => {
-    it('should sync custom tiles to Firebase (disabled defaults sync separately)', async () => {
-      const mockCustomTiles = [
-        {
-          id: 1,
-          group_id: 'custom-group-id',
-          intensity: 1,
-          action: 'Custom action',
-          tags: [],
-          isEnabled: 1,
-          isCustom: 1,
-          locale: 'en',
-          gameMode: 'online',
-        },
-      ];
+  describe('syncAllDataToFirebase (one write per push)', () => {
+    const mockCustomTiles = [
+      {
+        id: 1,
+        group_id: 'custom-group-id',
+        intensity: 1,
+        action: 'Custom action',
+        tags: [],
+        isEnabled: 1,
+        isCustom: 1,
+        locale: 'en',
+        gameMode: 'online',
+      },
+    ];
 
-      vi.mocked(getTiles).mockImplementation(async (filters: any) => {
-        if (filters?.isCustom === 1) return mockCustomTiles;
-        return [];
-      });
-
+    it('publishes every section in a single merge write', async () => {
+      const mockUserGroups = [{ id: 1, name: 'My Custom Group', isDefault: false, locale: 'en' }];
+      vi.mocked(getTiles).mockImplementation(async (filters: any) =>
+        filters?.isCustom === 1 ? (mockCustomTiles as any) : []
+      );
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) =>
+        filters?.isDefault === false ? (mockUserGroups as any) : []
+      );
+      vi.mocked(getBoards).mockResolvedValue([{ title: 'Board', tiles: [], isActive: 1 }] as any);
+      vi.mocked(useSettingsStore.getState).mockReturnValue({
+        settings: { locale: 'en', localPlayers: [{ name: 'device only' }], gone: undefined },
+        updateSettings: vi.fn(),
+      } as any);
       vi.mocked(setDoc).mockResolvedValue(undefined);
 
-      const result = await syncCustomTilesToFirebase();
+      const result = await syncAllDataToFirebase();
 
       expect(result).toBe(true);
-      expect(getTiles).toHaveBeenCalledWith({ isCustom: 1 });
-      const payload = vi.mocked(setDoc).mock.calls[0][1] as any;
+      // The whole point of the card: six sequential writes became one.
+      expect(setDoc).toHaveBeenCalledTimes(1);
+      const [, payload, options] = vi.mocked(setDoc).mock.calls[0] as any[];
+      expect(options).toEqual({ merge: true });
       expect(payload.customTiles).toEqual(mockCustomTiles);
-      // Disabled defaults are no longer bundled into the custom-tiles push.
-      expect(payload).not.toHaveProperty('disabledDefaults');
+      expect(payload.customGroups).toEqual(mockUserGroups);
+      expect(payload.customGroupExtensions).toEqual([]);
+      expect(payload.disabledDefaultsV2).toEqual([]);
+      expect(payload.disabledDefaults).toEqual([]);
+      expect(payload.gameBoards).toHaveLength(1);
+      expect(payload.lastUpdated).toBeInstanceOf(Date);
+      // Device-local and undefined settings never leave the device.
+      expect(payload.settings).toEqual({ locale: 'en' });
+    });
+
+    it("omits gameBoards when this device has none, so it cannot blank another device's", async () => {
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(getBoards).mockResolvedValue([]);
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      await syncAllDataToFirebase();
+
+      const payload = vi.mocked(setDoc).mock.calls[0][1] as any;
+      expect(payload).not.toHaveProperty('gameBoards');
     });
 
     it('writes legacy + V2 disabled-default fields, capping the legacy array at 100', async () => {
@@ -138,10 +179,12 @@ describe('syncService', () => {
         active: false,
         updatedAt: 100,
       });
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
       vi.mocked(getAllDisabledRecords).mockResolvedValue(records as any);
       vi.mocked(setDoc).mockResolvedValue(undefined);
 
-      const result = await syncDisabledDefaultsToFirebase();
+      const result = await syncAllDataToFirebase();
 
       expect(result).toBe(true);
       const payload = vi.mocked(setDoc).mock.calls[0][1] as any;
@@ -152,10 +195,34 @@ describe('syncService', () => {
       expect(payload.disabledDefaults.every((d: any) => d.action !== 'T')).toBe(true);
     });
 
+    it('drops disabled-default records above the V2 cap, loudly', async () => {
+      const records = Array.from({ length: 1005 }, (_, i) => ({
+        key: `g1|1|A${i}`,
+        group_id: 'g1',
+        intensity: 1,
+        action: `A${i}`,
+        active: false,
+        updatedAt: 100,
+      }));
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+      vi.mocked(getAllDisabledRecords).mockResolvedValue(records as any);
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await syncAllDataToFirebase();
+
+      const payload = vi.mocked(setDoc).mock.calls[0][1] as any;
+      expect(payload.disabledDefaultsV2).toHaveLength(1000);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
     it('should return false when user is not logged in', async () => {
       vi.mocked(getAuth).mockReturnValue({ currentUser: null } as any);
 
-      const result = await syncCustomTilesToFirebase();
+      const result = await syncAllDataToFirebase();
 
       expect(result).toBe(false);
       expect(getTiles).not.toHaveBeenCalled();
@@ -164,16 +231,33 @@ describe('syncService', () => {
 
     it('should handle Firebase errors gracefully', async () => {
       vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
       vi.mocked(setDoc).mockRejectedValue(new Error('Firebase error'));
 
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-      const result = await syncCustomTilesToFirebase();
+      const result = await syncAllDataToFirebase();
 
       expect(result).toBe(false);
-      expect(consoleSpy).toHaveBeenCalledWith('Error syncing custom tiles:', expect.any(Error));
+      expect(consoleSpy).toHaveBeenCalledWith('Error syncing data to Firebase:', expect.any(Error));
 
       consoleSpy.mockRestore();
+    });
+
+    it('pushes only user-created groups, never default ones', async () => {
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) =>
+        filters?.isDefault === false
+          ? ([{ id: 1, name: 'Mine', isDefault: false }] as any)
+          : ([{ id: 9, name: 'Default', isDefault: true, intensities: [] }] as any)
+      );
+      vi.mocked(setDoc).mockResolvedValue(undefined);
+
+      await syncAllDataToFirebase();
+
+      expect(getCustomGroups).toHaveBeenCalledWith({ isDefault: false });
+      const payload = vi.mocked(setDoc).mock.calls[0][1] as any;
+      expect(payload.customGroups).toEqual([{ id: 1, name: 'Mine', isDefault: false }]);
     });
   });
 
@@ -297,6 +381,62 @@ describe('syncService', () => {
         ])
       );
       expect(reconcileDisabledRows).toHaveBeenCalled();
+    });
+
+    it('publishes once after every merge, never per entity', async () => {
+      // Local content plus different remote content forces the merge path, which
+      // used to push from inside each entity sync — three writes racing.
+      vi.mocked(getDoc).mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          customTiles: [
+            {
+              id: 9,
+              group_id: 'remote-group-id',
+              intensity: 1,
+              action: 'Remote action',
+              tags: [],
+              isEnabled: 1,
+              isCustom: 1,
+            },
+          ],
+          customGroups: [],
+        }),
+      } as any);
+      vi.mocked(getTiles).mockImplementation(async (filters: any) =>
+        filters?.isCustom === 1
+          ? ([
+              {
+                id: 1,
+                group_id: 'local-group-id',
+                intensity: 1,
+                action: 'Local action',
+                isCustom: 1,
+              },
+            ] as any)
+          : []
+      );
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      expect(addCustomTile).toHaveBeenCalled();
+      expect(setDoc).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not push when no merge changed anything', async () => {
+      vi.mocked(getDoc).mockResolvedValue({
+        exists: () => true,
+        data: () => ({ customTiles: [], customGroups: [], disabledDefaultsV2: [], settings: {} }),
+      } as any);
+      vi.mocked(getTiles).mockResolvedValue([]);
+      vi.mocked(getCustomGroups).mockResolvedValue([]);
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      // A no-op pull that pushed would echo straight back through the listener.
+      expect(setDoc).not.toHaveBeenCalled();
     });
 
     it('should handle case where disabled defaults are not in Firebase data', async () => {
@@ -595,86 +735,6 @@ describe('syncService', () => {
     });
   });
 
-  describe('syncCustomGroupsToFirebase', () => {
-    it('should sync only user-created groups, not default groups', async () => {
-      const mockUserGroups = [
-        {
-          id: 1,
-          title: 'My Custom Group',
-          isDefault: false,
-          locale: 'en',
-        },
-        {
-          id: 2,
-          title: 'Another Custom Group',
-          isDefault: false,
-          locale: 'en',
-        },
-      ];
-
-      // Mock getCustomGroups to return user groups when isDefault: false filter is applied
-      vi.mocked(getCustomGroups).mockImplementation(async (filters: any) => {
-        if (filters?.isDefault === false) return mockUserGroups as any;
-        return [];
-      });
-
-      vi.mocked(setDoc).mockResolvedValue(undefined);
-
-      const result = await syncCustomGroupsToFirebase();
-
-      expect(result).toBe(true);
-      expect(getCustomGroups).toHaveBeenCalledWith({ isDefault: false });
-      expect(setDoc).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          customGroups: mockUserGroups,
-          lastUpdated: expect.any(Date),
-        }),
-        { merge: true }
-      );
-    });
-
-    it('should handle empty user groups correctly', async () => {
-      vi.mocked(getCustomGroups).mockResolvedValue([]);
-      vi.mocked(setDoc).mockResolvedValue(undefined);
-
-      const result = await syncCustomGroupsToFirebase();
-
-      expect(result).toBe(true);
-      expect(setDoc).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          customGroups: [],
-          lastUpdated: expect.any(Date),
-        }),
-        { merge: true }
-      );
-    });
-
-    it('should return false when user is not logged in', async () => {
-      vi.mocked(getAuth).mockReturnValue({ currentUser: null } as any);
-
-      const result = await syncCustomGroupsToFirebase();
-
-      expect(result).toBe(false);
-      expect(getCustomGroups).not.toHaveBeenCalled();
-    });
-
-    it('should handle Firebase errors gracefully', async () => {
-      vi.mocked(getCustomGroups).mockResolvedValue([]);
-      vi.mocked(setDoc).mockRejectedValue(new Error('Firebase error'));
-
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-      const result = await syncCustomGroupsToFirebase();
-
-      expect(result).toBe(false);
-      expect(consoleSpy).toHaveBeenCalledWith('Error syncing custom groups:', expect.any(Error));
-
-      consoleSpy.mockRestore();
-    });
-  });
-
   describe('integration scenarios', () => {
     it('should handle complete login workflow without data loss', async () => {
       // Simulate user workflow:
@@ -721,7 +781,7 @@ describe('syncService', () => {
       vi.mocked(setDoc).mockResolvedValue(undefined);
 
       // Test upload
-      const uploadResult = await syncCustomTilesToFirebase();
+      const uploadResult = await syncAllDataToFirebase();
       expect(uploadResult).toBe(true);
 
       // Mock the download (when user logs back in)

--- a/src/services/__tests__/syncService.test.ts
+++ b/src/services/__tests__/syncService.test.ts
@@ -424,6 +424,36 @@ describe('syncService', () => {
       expect(setDoc).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps extension records for groups this device has not seeded', async () => {
+      // CustomGroupExtensionsSync skips an unknown group expecting the record to
+      // survive in the cloud; a blind local snapshot would delete it.
+      const unseeded = {
+        groupName: 'ballBusting',
+        locale: 'de',
+        gameMode: 'local',
+        intensities: [{ value: 5, label: 'Brutal' }],
+      };
+      vi.mocked(getDoc).mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          customTiles: [],
+          customGroupExtensions: [unseeded],
+        }),
+      } as any);
+      // Local content with an empty cloud tiles list forces the cycle to publish.
+      vi.mocked(getTiles).mockImplementation(async (filters: any) =>
+        filters?.isCustom === 1
+          ? ([{ id: 1, group_id: 'g', intensity: 1, action: 'Local', isCustom: 1 }] as any)
+          : []
+      );
+
+      const result = await syncDataFromFirebase();
+
+      expect(result).toBe(true);
+      const payload = vi.mocked(setDoc).mock.calls[0][1] as any;
+      expect(payload.customGroupExtensions).toEqual([unseeded]);
+    });
+
     it('does not push when no merge changed anything', async () => {
       vi.mocked(getDoc).mockResolvedValue({
         exists: () => true,

--- a/src/services/sync/__tests__/remoteUserData.test.ts
+++ b/src/services/sync/__tests__/remoteUserData.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/firebase', () => ({ db: {} }));
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(),
+  getDoc: vi.fn(),
+  setDoc: vi.fn(),
+}));
+
+import { decodeRemoteUserData } from '../remoteUserData';
+
+describe('decodeRemoteUserData', () => {
+  it('reports absent sections as undefined, so a merge never treats them as emptied', () => {
+    const decoded = decodeRemoteUserData({});
+
+    expect(decoded.customTiles).toBeUndefined();
+    expect(decoded.customGroups).toBeUndefined();
+    expect(decoded.groupExtensions).toBeUndefined();
+    expect(decoded.disabledDefaults).toBeUndefined();
+    expect(decoded.gameBoards).toBeUndefined();
+    expect(decoded.settings).toBeUndefined();
+  });
+
+  it('distinguishes a present-but-empty section from an absent one', () => {
+    const decoded = decodeRemoteUserData({ customTiles: [], settings: {} });
+
+    expect(decoded.customTiles).toEqual([]);
+    expect(decoded.settings).toEqual({});
+    expect(decoded.customGroups).toBeUndefined();
+  });
+
+  it('prefers the V2 disabled-defaults field when both are present', () => {
+    const v2 = [
+      { key: 'g|1|A', group_id: 'g', intensity: 1, action: 'A', active: false, updatedAt: 500 },
+    ];
+    const decoded = decodeRemoteUserData({
+      disabledDefaultsV2: v2,
+      disabledDefaults: [{ group_id: 'g', intensity: 1, action: 'A' }],
+    });
+
+    // The tombstone survives: taking the legacy array here would resurrect it as
+    // active and undo a re-enable made on another device.
+    expect(decoded.disabledDefaults).toEqual(v2);
+  });
+
+  it('up-converts a legacy-only document into active records stamped 1', () => {
+    const decoded = decodeRemoteUserData({
+      disabledDefaults: [
+        { group_id: 'g', intensity: 2, action: 'Legacy' },
+        { group_id: 'g', intensity: 2 }, // no action — unusable, dropped
+      ],
+    });
+
+    expect(decoded.disabledDefaults).toEqual([
+      {
+        key: 'g|2|Legacy',
+        group_id: 'g',
+        intensity: 2,
+        action: 'Legacy',
+        active: true,
+        updatedAt: 1,
+      },
+    ]);
+  });
+
+  it('reads group extensions from the document field name', () => {
+    const records = [
+      { groupName: 'ballBusting', locale: 'en', gameMode: 'online', intensities: [] },
+    ];
+    const decoded = decodeRemoteUserData({ customGroupExtensions: records });
+
+    expect(decoded.groupExtensions).toEqual(records);
+  });
+
+  it('treats a null section as empty rather than throwing', () => {
+    const decoded = decodeRemoteUserData({ customTiles: null, gameBoards: null });
+
+    expect(decoded.customTiles).toEqual([]);
+    expect(decoded.gameBoards).toEqual([]);
+  });
+});

--- a/src/services/sync/base.ts
+++ b/src/services/sync/base.ts
@@ -79,10 +79,11 @@ export class SyncBase {
   /**
    * Create success result
    */
-  static createSuccessResult(itemsProcessed = 0): SyncResult {
+  static createSuccessResult(itemsProcessed = 0, changed = false): SyncResult {
     return {
       success: true,
       itemsProcessed,
+      changed,
     };
   }
 }

--- a/src/services/sync/base.ts
+++ b/src/services/sync/base.ts
@@ -2,8 +2,6 @@
  * Base utilities for sync operations
  */
 import { getAuth } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
-import { db } from '@/services/firebase';
 import type { SyncResult } from '@/types/sync';
 
 export const SYNC_DELAY_MS = 50;
@@ -21,14 +19,6 @@ export class SyncBase {
     }
 
     return user;
-  }
-
-  /**
-   * Get user document from Firebase
-   */
-  static async getUserDocument(userId: string) {
-    const userDocRef = doc(db, 'user-data', userId);
-    return await getDoc(userDocRef);
   }
 
   /**

--- a/src/services/sync/customGroupsSync.ts
+++ b/src/services/sync/customGroupsSync.ts
@@ -1,5 +1,5 @@
 import type { SyncOptions, SyncResult } from '@/types/sync';
-import { clearUserCustomGroups, syncCustomGroupsToFirebase } from '../syncService';
+import { clearUserCustomGroups } from './localCleanup';
 /**
  * Custom groups synchronization logic
  */
@@ -20,9 +20,9 @@ export class CustomGroupsSync extends SyncBase {
       const localGroups = await getCustomGroups({ isDefault: false });
 
       // Smart conflict resolution
+      // Cloud has nothing, this device does: the cycle's single push publishes it.
       if (firebaseGroups.length === 0 && localGroups.length > 0 && !options.forceSync) {
-        await syncCustomGroupsToFirebase();
-        return this.createSuccessResult(localGroups.length);
+        return this.createSuccessResult(localGroups.length, true);
       }
 
       if (firebaseGroups.length > 0 && localGroups.length > 0 && !options.forceSync) {
@@ -66,13 +66,7 @@ export class CustomGroupsSync extends SyncBase {
       }
     }
 
-    // Only push back when groups were actually added — otherwise the real-time
-    // listener would echo every pull into a push.
-    if (addedCount > 0) {
-      await syncCustomGroupsToFirebase();
-    }
-
-    return this.createSuccessResult(addedCount + localGroups.length);
+    return this.createSuccessResult(addedCount + localGroups.length, addedCount > 0);
   }
 
   /**

--- a/src/services/sync/customTilesSync.ts
+++ b/src/services/sync/customTilesSync.ts
@@ -9,7 +9,7 @@ import {
   getTiles,
   updateCustomTile,
 } from '@/stores/customTiles';
-import { deleteAllCustomTiles, syncCustomTilesToFirebase } from '../syncService';
+import { deleteAllCustomTiles } from './localCleanup';
 
 import type { CustomTilePull } from '@/types/customTiles';
 import { SyncBase } from './base';
@@ -46,9 +46,9 @@ export class CustomTilesSync extends SyncBase {
       }
 
       // Smart conflict resolution
+      // Cloud has nothing, this device does: the cycle's single push publishes it.
       if (firebaseTiles.length === 0 && localTiles.length > 0 && !options.forceSync) {
-        await syncCustomTilesToFirebase();
-        return this.createSuccessResult(localTiles.length);
+        return this.createSuccessResult(localTiles.length, true);
       }
 
       if (firebaseTiles.length > 0 && localTiles.length > 0 && !options.forceSync) {
@@ -119,13 +119,12 @@ export class CustomTilesSync extends SyncBase {
       }
     }
 
-    // Only push the merged result back when something actually changed —
-    // otherwise the real-time listener would echo every pull into a push.
-    if (addedCount + updatedCount > 0) {
-      await syncCustomTilesToFirebase();
-    }
-
-    return this.createSuccessResult(addedCount + updatedCount + localTiles.length);
+    // Report the change instead of pushing here: a push per entity raced the
+    // other merges and echoed every pull back through the real-time listener.
+    return this.createSuccessResult(
+      addedCount + updatedCount + localTiles.length,
+      addedCount + updatedCount > 0
+    );
   }
 
   /**

--- a/src/services/sync/disabledDefaultsSync.ts
+++ b/src/services/sync/disabledDefaultsSync.ts
@@ -6,62 +6,29 @@
  * per-record last-writer-wins, so re-enables propagate across devices and the
  * old whole-list-replace + 100-cap data loss is gone.
  *
- * Back-compat: new clients write `disabledDefaultsV2` (full records) plus a
- * legacy `disabledDefaults` array (active-only) for pre-V2 clients. On pull we
- * prefer V2; when only the legacy array exists (written by an old client) we
- * import its entries as active records.
+ * Back-compat lives in the document owner (`remoteUserData`): it resolves the
+ * V2 field against the legacy `disabledDefaults` array, so this merge only ever
+ * sees records.
  */
 import { SyncBase } from './base';
 import { mergeRemoteDisabledRecords, reconcileDisabledRows } from '@/stores/disabledDefaults';
-import { syncDisabledDefaultsToFirebase } from '../syncService';
 import type { DisabledDefault } from '@/types/customTiles';
 import type { SyncResult } from '@/types/sync';
 
-interface LegacyDisabled {
-  group_id?: string;
-  intensity: number;
-  action: string;
-}
-
-function legacyToRecords(legacy: LegacyDisabled[]): DisabledDefault[] {
-  // No timestamp in the legacy shape; stamp 1 so any genuine V2 edit wins, but
-  // a first-time import still applies over the never-seen local default (-1).
-  return legacy
-    .filter((t) => t && typeof t.action === 'string')
-    .map((t) => ({
-      key: `${t.group_id}|${t.intensity}|${t.action}`,
-      group_id: t.group_id,
-      intensity: t.intensity,
-      action: t.action,
-      active: true,
-      updatedAt: 1,
-    }));
-}
-
 export class DisabledDefaultsSync extends SyncBase {
-  /**
-   * @param v2 the `disabledDefaultsV2` field (preferred) or undefined
-   * @param legacy the legacy `disabledDefaults` array (fallback)
-   */
-  static async syncFromFirebase(
-    v2: DisabledDefault[] | undefined,
-    legacy: LegacyDisabled[] | undefined
-  ): Promise<SyncResult> {
+  static async syncFromFirebase(remote: DisabledDefault[]): Promise<SyncResult> {
     try {
-      const remote = Array.isArray(v2) ? v2 : legacyToRecords(legacy ?? []);
-
       const changed = await mergeRemoteDisabledRecords(remote);
 
-      // Only touch row flags / push back when the merge actually changed the
-      // table. A no-op pull means rows are already consistent (reconciled on the
-      // prior change and after migration), so we skip the full default scan and
-      // avoid echoing our own apply through the real-time listener.
+      // Only touch row flags when the merge actually changed the table. A no-op
+      // pull means rows are already consistent (reconciled on the prior change
+      // and after migration), so we skip the full default scan — and report no
+      // change, so the cycle doesn't echo its own apply back to the cloud.
       if (changed > 0) {
         await reconcileDisabledRows();
-        await syncDisabledDefaultsToFirebase();
       }
 
-      return this.createSuccessResult(changed);
+      return this.createSuccessResult(changed, changed > 0);
     } catch (error) {
       return this.handleSyncError('disabled defaults sync', error);
     }

--- a/src/services/sync/index.ts
+++ b/src/services/sync/index.ts
@@ -2,6 +2,8 @@
  * Sync module exports
  */
 export * from './base';
+export * from './remoteUserData';
+export * from './localCleanup';
 export * from './customTilesSync';
 export * from './customGroupsSync';
 export * from './disabledDefaultsSync';

--- a/src/services/sync/localCleanup.ts
+++ b/src/services/sync/localCleanup.ts
@@ -1,0 +1,80 @@
+/**
+ * Local-side repairs the sync path performs on Dexie before or during a merge.
+ *
+ * These live below the sync modules rather than in `syncService` so the entity
+ * syncs can use them without importing their own caller.
+ */
+import {
+  deleteAllIsCustomTiles,
+  deleteCustomTile,
+  getTiles,
+  updateCustomTile,
+} from '@/stores/customTiles';
+import { getCustomGroups } from '@/stores/customGroups';
+import { deleteGroup } from '@/stores/contentLibrary';
+
+export const deleteAllCustomTiles = deleteAllIsCustomTiles;
+
+/**
+ * Collapse tiles that an earlier sync bug duplicated: keep the lowest id, and
+ * carry a disabled state over from any duplicate so the user's intent survives.
+ */
+export async function cleanupDuplicateTiles(): Promise<boolean> {
+  try {
+    const allTiles = await getTiles({});
+
+    const tileGroups = new Map<string, typeof allTiles>();
+    allTiles.forEach((tile) => {
+      const key = `${tile.group_id}|${tile.intensity}|${tile.action}`;
+      if (!tileGroups.has(key)) {
+        tileGroups.set(key, []);
+      }
+      tileGroups.get(key)!.push(tile);
+    });
+
+    for (const [, tiles] of tileGroups) {
+      if (tiles.length > 1) {
+        tiles.sort((a, b) => (a.id || 0) - (b.id || 0));
+        const original = tiles[0];
+        const duplicates = tiles.slice(1);
+
+        const wasDisabled = duplicates.some((tile) => tile.isEnabled === 0);
+
+        for (const duplicate of duplicates) {
+          if (duplicate.id) {
+            await deleteCustomTile(duplicate.id);
+          }
+        }
+
+        if (wasDisabled && original.isEnabled === 1) {
+          await updateCustomTile(original.id!, { isEnabled: 0 });
+        }
+      }
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error cleaning up duplicate tiles:', error);
+    return false;
+  }
+}
+
+/** Clear user-created groups ahead of a full replace-from-cloud. */
+export async function clearUserCustomGroups(): Promise<boolean> {
+  try {
+    const userGroups = await getCustomGroups({ isDefault: false });
+
+    // Deliberately NOT cascadeDelete: deleteGroup refuses tile-owning groups,
+    // which is load-bearing here. The re-import that follows strips incoming
+    // ids and re-adds tiles under fresh local ids, so cascading would destroy
+    // tiles the pull cannot faithfully restore. A refused delete still counts
+    // as success — the group is about to be overwritten by the cloud copy.
+    const deletePromises = userGroups.map((group) => deleteGroup(group.id));
+    await Promise.all(deletePromises);
+
+    return true;
+  } catch (error) {
+    console.error('Error deleting user custom groups:', error);
+    return false;
+  }
+}

--- a/src/services/sync/remoteUserData.ts
+++ b/src/services/sync/remoteUserData.ts
@@ -151,8 +151,24 @@ export async function collectLocalUserData(): Promise<LocalUserData> {
   };
 }
 
-/** Publish the snapshot in a single merge write. */
-export async function writeRemoteUserData(uid: string, local: LocalUserData): Promise<void> {
+function extensionKey(record: GroupExtensionRecord): string {
+  return JSON.stringify([record.groupName, record.locale, record.gameMode]);
+}
+
+/**
+ * Publish the snapshot in a single merge write.
+ *
+ * `remote`, when the caller already holds the cloud snapshot, keeps extension
+ * records for groups this device has not seeded (a locale it never loaded, or an
+ * older app version). `CustomGroupExtensionsSync` skips those on pull expecting
+ * them to survive in the cloud until the group exists, and a blind local
+ * snapshot would delete them.
+ */
+export async function writeRemoteUserData(
+  uid: string,
+  local: LocalUserData,
+  remote?: RemoteUserData | null
+): Promise<void> {
   let records = local.disabledDefaults;
   if (records.length > DISABLED_V2_MAX) {
     const dropped = records.length - DISABLED_V2_MAX;
@@ -170,12 +186,20 @@ export async function writeRemoteUserData(uid: string, local: LocalUserData): Pr
     legacyActive.splice(LEGACY_DISABLED_CAP);
   }
 
+  const knownExtensions = new Set(local.groupExtensions.map(extensionKey));
+  const groupExtensions = [
+    ...local.groupExtensions,
+    ...(remote?.groupExtensions ?? []).filter(
+      (record) => record && !knownExtensions.has(extensionKey(record))
+    ),
+  ];
+
   await setDoc(
     userDoc(uid),
     {
       customTiles: local.customTiles,
       customGroups: local.customGroups,
-      customGroupExtensions: local.groupExtensions,
+      customGroupExtensions: groupExtensions,
       disabledDefaults: legacyActive,
       disabledDefaultsV2: records,
       // A device with no boards must not blank another device's — an empty

--- a/src/services/sync/remoteUserData.ts
+++ b/src/services/sync/remoteUserData.ts
@@ -1,0 +1,189 @@
+/**
+ * Owner of the `user-data/{uid}` Firestore document.
+ *
+ * That document is one ~1 MiB blob holding every account-scoped section (tiles,
+ * groups, default-group extensions, disabled defaults, boards, settings). This
+ * module is the only place that knows its field names and its encoding quirks:
+ * the dual legacy/V2 disabled-defaults fields, the caps that keep the blob
+ * bounded, and which sections may be written as empty. Everything above it works
+ * in the app's own vocabulary and reads/writes the snapshot once per cycle.
+ */
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { db } from '@/services/firebase';
+import { getTiles } from '@/stores/customTiles';
+import { getCustomGroups } from '@/stores/customGroups';
+import { getAllDisabledRecords } from '@/stores/disabledDefaults';
+import { getBoards } from '@/stores/gameBoard';
+import { useSettingsStore } from '@/stores/settingsStore';
+import {
+  collectGroupExtensionRecords,
+  type GroupExtensionRecord,
+} from './customGroupExtensionsSync';
+import type { CustomGroupPull } from '@/types/customGroups';
+import type { CustomTilePull, DisabledDefault } from '@/types/customTiles';
+import type { DBGameBoard } from '@/types/gameBoard';
+
+// Old clients read a flat `disabledDefaults` array (no tombstones) and skip it
+// entirely when it exceeds 100, so we best-effort cap the legacy field there.
+const LEGACY_DISABLED_CAP = 100;
+// The full record set (incl. tombstones) shares the single ~1 MiB `user-data`
+// doc with tiles/groups/boards/settings, so it must stay bounded. Genuine usage
+// is small; exceeding this signals corruption — drop loudly, never silently.
+const DISABLED_V2_MAX = 1000;
+
+/**
+ * A section left `undefined` is one the document does not carry — callers must
+ * distinguish "absent" (never synced from this account) from "present but
+ * empty" (deliberately emptied), because only the latter may overwrite local
+ * content.
+ */
+export interface RemoteUserData {
+  customTiles?: CustomTilePull[];
+  customGroups?: CustomGroupPull[];
+  groupExtensions?: GroupExtensionRecord[];
+  /** V2 records; a legacy-only document is up-converted here. */
+  disabledDefaults?: DisabledDefault[];
+  gameBoards?: DBGameBoard[];
+  settings?: Record<string, unknown>;
+}
+
+/** Everything this device would publish, in one snapshot. */
+export interface LocalUserData {
+  customTiles: CustomTilePull[];
+  customGroups: CustomGroupPull[];
+  groupExtensions: GroupExtensionRecord[];
+  disabledDefaults: DisabledDefault[];
+  gameBoards: DBGameBoard[];
+  settings: Record<string, unknown>;
+}
+
+interface LegacyDisabled {
+  group_id?: string;
+  intensity: number;
+  action: string;
+}
+
+/**
+ * Up-convert the pre-tombstone array. No timestamp exists in that shape, so
+ * stamp 1: any genuine V2 edit outranks it, while a first-time import still
+ * applies over the never-seen local default (-1).
+ */
+function legacyToRecords(legacy: LegacyDisabled[]): DisabledDefault[] {
+  return legacy
+    .filter((t) => t && typeof t.action === 'string')
+    .map((t) => ({
+      key: `${t.group_id}|${t.intensity}|${t.action}`,
+      group_id: t.group_id,
+      intensity: t.intensity,
+      action: t.action,
+      active: true,
+      updatedAt: 1,
+    }));
+}
+
+function userDoc(uid: string) {
+  return doc(db, 'user-data', uid);
+}
+
+/** Decode the cloud snapshot. `null` means the account has no document yet. */
+export async function readRemoteUserData(uid: string): Promise<RemoteUserData | null> {
+  const snapshot = await getDoc(userDoc(uid));
+  if (!snapshot.exists()) return null;
+  return decodeRemoteUserData(snapshot.data());
+}
+
+/**
+ * The document's field names stop here. Exported for tests and for the
+ * real-time listener, which already holds a snapshot's data.
+ */
+export function decodeRemoteUserData(data: Record<string, any> | undefined): RemoteUserData {
+  const raw = data ?? {};
+  const hasV2 = raw.disabledDefaultsV2 !== undefined;
+  const hasLegacy = raw.disabledDefaults !== undefined;
+
+  return {
+    customTiles:
+      raw.customTiles === undefined ? undefined : ((raw.customTiles || []) as CustomTilePull[]),
+    customGroups:
+      raw.customGroups === undefined ? undefined : ((raw.customGroups || []) as CustomGroupPull[]),
+    groupExtensions:
+      raw.customGroupExtensions === undefined
+        ? undefined
+        : ((raw.customGroupExtensions || []) as GroupExtensionRecord[]),
+    disabledDefaults:
+      !hasV2 && !hasLegacy
+        ? undefined
+        : Array.isArray(raw.disabledDefaultsV2)
+          ? (raw.disabledDefaultsV2 as DisabledDefault[])
+          : legacyToRecords((raw.disabledDefaults ?? []) as LegacyDisabled[]),
+    gameBoards:
+      raw.gameBoards === undefined ? undefined : ((raw.gameBoards || []) as DBGameBoard[]),
+    settings:
+      raw.settings === undefined ? undefined : ((raw.settings || {}) as Record<string, unknown>),
+  };
+}
+
+/** Snapshot everything this device would publish, from Dexie and the store. */
+export async function collectLocalUserData(): Promise<LocalUserData> {
+  const [customTiles, customGroups, groupExtensions, disabledDefaults, gameBoards] =
+    await Promise.all([
+      getTiles({ isCustom: 1 }),
+      getCustomGroups({ isDefault: false }),
+      collectGroupExtensionRecords(),
+      getAllDisabledRecords(),
+      getBoards(),
+    ]);
+
+  const { settings } = useSettingsStore.getState();
+  // localPlayers is device-local by design, and Firestore rejects undefined.
+  const { localPlayers: _localPlayers, ...shareable } = settings;
+  const cleanSettings = Object.fromEntries(
+    Object.entries(shareable).filter(([, value]) => value !== undefined)
+  );
+
+  return {
+    customTiles: customTiles as CustomTilePull[],
+    customGroups,
+    groupExtensions,
+    disabledDefaults,
+    gameBoards,
+    settings: cleanSettings,
+  };
+}
+
+/** Publish the snapshot in a single merge write. */
+export async function writeRemoteUserData(uid: string, local: LocalUserData): Promise<void> {
+  let records = local.disabledDefaults;
+  if (records.length > DISABLED_V2_MAX) {
+    const dropped = records.length - DISABLED_V2_MAX;
+    console.warn(
+      `⚠️ ${records.length} disabled-default records exceeds the ${DISABLED_V2_MAX} cap; ` +
+        `dropping ${dropped} from sync. This likely indicates corrupted local data.`
+    );
+    records = records.slice(0, DISABLED_V2_MAX);
+  }
+
+  const legacyActive = records
+    .filter((r) => r.active)
+    .map((r) => ({ group_id: r.group_id, intensity: r.intensity, action: r.action }));
+  if (legacyActive.length > LEGACY_DISABLED_CAP) {
+    legacyActive.splice(LEGACY_DISABLED_CAP);
+  }
+
+  await setDoc(
+    userDoc(uid),
+    {
+      customTiles: local.customTiles,
+      customGroups: local.customGroups,
+      customGroupExtensions: local.groupExtensions,
+      disabledDefaults: legacyActive,
+      disabledDefaultsV2: records,
+      // A device with no boards must not blank another device's — an empty
+      // local list means "nothing to contribute", not "delete what is there".
+      ...(local.gameBoards.length > 0 ? { gameBoards: local.gameBoards } : {}),
+      settings: local.settings,
+      lastUpdated: new Date(),
+    },
+    { merge: true }
+  );
+}

--- a/src/services/sync/syncOrchestrator.ts
+++ b/src/services/sync/syncOrchestrator.ts
@@ -1,71 +1,77 @@
+/**
+ * Coordinates one sync cycle: read the cloud snapshot once, run every entity
+ * merge against it, then publish once if anything changed.
+ *
+ * The document itself belongs to `remoteUserData`; nothing here knows its field
+ * names, and nothing below here writes to it.
+ */
 import type { SyncOptions, SyncResult } from '@/types/sync';
-import { cleanupDuplicateTiles, syncAllDataToFirebase } from '../syncService';
+import type { RemoteUserData } from './remoteUserData';
+import { collectLocalUserData, readRemoteUserData, writeRemoteUserData } from './remoteUserData';
+import { cleanupDuplicateTiles } from './localCleanup';
 
 import { CustomGroupExtensionsSync } from './customGroupExtensionsSync';
 import { CustomGroupsSync } from './customGroupsSync';
-/**
- * Main sync orchestrator - coordinates all sync operations
- */
 import { CustomTilesSync } from './customTilesSync';
 import { DisabledDefaultsSync } from './disabledDefaultsSync';
 import { GameBoardsSync } from './gameBoardsSync';
 import { SettingsSync } from './settingsSync';
 import { SyncBase } from './base';
 
+const OPERATION_NAMES = [
+  'Custom Tiles',
+  'Custom Groups',
+  'Group Extensions',
+  'Disabled Defaults',
+  'Game Boards',
+  'Settings',
+];
+
 export class SyncOrchestrator extends SyncBase {
-  /**
-   * Main sync function - refactored from the original syncDataFromFirebase
-   */
   static async syncFromFirebase(options: SyncOptions = {}): Promise<boolean> {
     try {
       const user = this.getAuthenticatedUser();
-      const userDoc = await this.getUserDocument(user.uid);
+      const remote = await readRemoteUserData(user.uid);
 
-      if (!userDoc.exists()) {
-        return await syncAllDataToFirebase();
+      // No cloud document yet: this device's snapshot becomes the baseline.
+      if (!remote) {
+        return await this.publish(user.uid);
       }
-
-      const userData = userDoc.data();
 
       // Clean up any duplicate tiles first
       await cleanupDuplicateTiles();
 
       // Run all sync operations in parallel for better performance
-      const syncOperations = [
-        this.syncCustomTiles(userData, options),
-        this.syncCustomGroups(userData, options),
-        this.syncGroupExtensions(userData),
-        this.syncDisabledDefaults(userData),
-        this.syncGameBoards(userData),
-        this.syncSettings(userData),
-      ];
+      const results = await Promise.allSettled([
+        this.syncCustomTiles(remote, options),
+        this.syncCustomGroups(remote, options),
+        this.syncGroupExtensions(remote),
+        this.syncDisabledDefaults(remote),
+        this.syncGameBoards(remote),
+        this.syncSettings(remote),
+      ]);
 
-      const results = await Promise.allSettled(syncOperations);
-
-      // Check if all operations succeeded
       let totalSuccess = true;
+      let changed = false;
 
       results.forEach((result, index) => {
-        const operationNames = [
-          'Custom Tiles',
-          'Custom Groups',
-          'Group Extensions',
-          'Disabled Defaults',
-          'Game Boards',
-          'Settings',
-        ];
-
         if (result.status === 'fulfilled') {
-          const syncResult = result.value;
-          if (!syncResult.success) {
+          if (!result.value.success) {
             totalSuccess = false;
-            console.error(`❌ ${operationNames[index]} sync failed:`, syncResult.errors);
+            console.error(`❌ ${OPERATION_NAMES[index]} sync failed:`, result.value.errors);
           }
+          changed = changed || Boolean(result.value.changed);
         } else {
           totalSuccess = false;
-          console.error(`❌ ${operationNames[index]} sync rejected:`, result.reason);
+          console.error(`❌ ${OPERATION_NAMES[index]} sync rejected:`, result.reason);
         }
       });
+
+      // One write per cycle, after every merge has settled — a mid-merge push
+      // published a half-merged document and echoed back through the listener.
+      if (changed && !(await this.publish(user.uid))) {
+        totalSuccess = false;
+      }
 
       return totalSuccess;
     } catch (error) {
@@ -74,78 +80,59 @@ export class SyncOrchestrator extends SyncBase {
     }
   }
 
-  /**
-   * Sync custom tiles with error handling
-   */
-  private static async syncCustomTiles(userData: any, options: SyncOptions): Promise<SyncResult> {
-    if (userData.customTiles !== undefined) {
-      const tiles = userData.customTiles || [];
-
-      // Check if any are actually disabled defaults (this shouldn't happen)
-      const invalidTiles = tiles.filter((tile: any) => tile.isCustom === 0);
-      if (invalidTiles.length > 0) {
-        console.warn(
-          `⚠️ Found ${invalidTiles.length} default tiles in customTiles field - data corruption detected`
-        );
-      }
-
-      return await CustomTilesSync.syncFromFirebase(tiles, options);
+  private static async publish(uid: string): Promise<boolean> {
+    try {
+      await writeRemoteUserData(uid, await collectLocalUserData());
+      return true;
+    } catch (error) {
+      console.error('Error publishing user data:', error);
+      return false;
     }
-    return this.createSuccessResult(0);
   }
 
-  /**
-   * Sync custom groups with error handling
-   */
-  private static async syncCustomGroups(userData: any, options: SyncOptions): Promise<SyncResult> {
-    if (userData.customGroups !== undefined) {
-      return await CustomGroupsSync.syncFromFirebase(userData.customGroups || [], options);
-    }
-    return this.createSuccessResult(0);
-  }
+  private static async syncCustomTiles(
+    remote: RemoteUserData,
+    options: SyncOptions
+  ): Promise<SyncResult> {
+    if (remote.customTiles === undefined) return this.createSuccessResult(0);
 
-  /**
-   * Sync appended default-group intensity levels with error handling
-   */
-  private static async syncGroupExtensions(userData: any): Promise<SyncResult> {
-    if (userData.customGroupExtensions !== undefined) {
-      return await CustomGroupExtensionsSync.syncFromFirebase(userData.customGroupExtensions || []);
-    }
-    return this.createSuccessResult(0);
-  }
-
-  /**
-   * Sync disabled defaults with error handling. Prefers the per-record
-   * `disabledDefaultsV2` field, falling back to the legacy `disabledDefaults`
-   * array written by pre-V2 clients.
-   */
-  private static async syncDisabledDefaults(userData: any): Promise<SyncResult> {
-    if (userData.disabledDefaultsV2 !== undefined || userData.disabledDefaults !== undefined) {
-      return await DisabledDefaultsSync.syncFromFirebase(
-        userData.disabledDefaultsV2,
-        userData.disabledDefaults
+    const tiles = remote.customTiles;
+    // Disabled defaults live in their own field; one here means corrupt data.
+    const invalidTiles = tiles.filter((tile: any) => tile.isCustom === 0);
+    if (invalidTiles.length > 0) {
+      console.warn(
+        `⚠️ Found ${invalidTiles.length} default tiles in customTiles field - data corruption detected`
       );
     }
-    return this.createSuccessResult(0);
+
+    return await CustomTilesSync.syncFromFirebase(tiles, options);
   }
 
-  /**
-   * Sync game boards with error handling
-   */
-  private static async syncGameBoards(userData: any): Promise<SyncResult> {
-    if (userData.gameBoards !== undefined) {
-      return await GameBoardsSync.syncFromFirebase(userData.gameBoards);
-    }
-    return this.createSuccessResult(0);
+  private static async syncCustomGroups(
+    remote: RemoteUserData,
+    options: SyncOptions
+  ): Promise<SyncResult> {
+    if (remote.customGroups === undefined) return this.createSuccessResult(0);
+    return await CustomGroupsSync.syncFromFirebase(remote.customGroups, options);
   }
 
-  /**
-   * Sync settings with error handling
-   */
-  private static async syncSettings(userData: any): Promise<SyncResult> {
-    if (userData.settings !== undefined) {
-      return await SettingsSync.syncFromFirebase(userData.settings || {});
-    }
-    return this.createSuccessResult(0);
+  private static async syncGroupExtensions(remote: RemoteUserData): Promise<SyncResult> {
+    if (remote.groupExtensions === undefined) return this.createSuccessResult(0);
+    return await CustomGroupExtensionsSync.syncFromFirebase(remote.groupExtensions);
+  }
+
+  private static async syncDisabledDefaults(remote: RemoteUserData): Promise<SyncResult> {
+    if (remote.disabledDefaults === undefined) return this.createSuccessResult(0);
+    return await DisabledDefaultsSync.syncFromFirebase(remote.disabledDefaults);
+  }
+
+  private static async syncGameBoards(remote: RemoteUserData): Promise<SyncResult> {
+    if (remote.gameBoards === undefined) return this.createSuccessResult(0);
+    return await GameBoardsSync.syncFromFirebase(remote.gameBoards);
+  }
+
+  private static async syncSettings(remote: RemoteUserData): Promise<SyncResult> {
+    if (remote.settings === undefined) return this.createSuccessResult(0);
+    return await SettingsSync.syncFromFirebase(remote.settings);
   }
 }

--- a/src/services/sync/syncOrchestrator.ts
+++ b/src/services/sync/syncOrchestrator.ts
@@ -35,7 +35,7 @@ export class SyncOrchestrator extends SyncBase {
 
       // No cloud document yet: this device's snapshot becomes the baseline.
       if (!remote) {
-        return await this.publish(user.uid);
+        return await this.publish(user.uid, remote);
       }
 
       // Clean up any duplicate tiles first
@@ -69,7 +69,7 @@ export class SyncOrchestrator extends SyncBase {
 
       // One write per cycle, after every merge has settled — a mid-merge push
       // published a half-merged document and echoed back through the listener.
-      if (changed && !(await this.publish(user.uid))) {
+      if (changed && !(await this.publish(user.uid, remote))) {
         totalSuccess = false;
       }
 
@@ -80,9 +80,9 @@ export class SyncOrchestrator extends SyncBase {
     }
   }
 
-  private static async publish(uid: string): Promise<boolean> {
+  private static async publish(uid: string, remote?: RemoteUserData | null): Promise<boolean> {
     try {
-      await writeRemoteUserData(uid, await collectLocalUserData());
+      await writeRemoteUserData(uid, await collectLocalUserData(), remote);
       return true;
     } catch (error) {
       console.error('Error publishing user data:', error);

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -6,13 +6,12 @@
  * push, pull, periodic, real-time listener); the merge policy lives in
  * `sync/*Sync.ts` and the encoding in the owner.
  */
-import { doc, getFirestore, onSnapshot } from 'firebase/firestore';
+import { doc, onSnapshot } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
+import { db } from './firebase';
 import { beginSyncApply, endSyncApply } from './syncMiddleware';
 import { collectLocalUserData, writeRemoteUserData } from './sync/remoteUserData';
 import { cleanupDuplicateTiles, clearUserCustomGroups } from './sync/localCleanup';
-
-const db = getFirestore();
 
 export { cleanupDuplicateTiles, clearUserCustomGroups };
 export { deleteAllCustomTiles } from './sync/localCleanup';

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -1,388 +1,41 @@
-import {
-  deleteAllIsCustomTiles,
-  deleteCustomTile,
-  getTiles,
-  updateCustomTile,
-} from '@/stores/customTiles';
-import { getCustomGroups } from '@/stores/customGroups';
-import { deleteGroup } from '@/stores/contentLibrary';
-import { doc, getDoc, onSnapshot, setDoc } from 'firebase/firestore';
-
-import { CustomGroupPull } from '@/types/customGroups';
-import { CustomTilePull } from '@/types/customTiles';
+/**
+ * Account-scoped cloud sync: the public entry points the app calls.
+ *
+ * The `user-data/{uid}` document itself is owned by `sync/remoteUserData.ts` —
+ * one read and one write per cycle. This file decides *when* a cycle runs (login
+ * push, pull, periodic, real-time listener); the merge policy lives in
+ * `sync/*Sync.ts` and the encoding in the owner.
+ */
+import { doc, getFirestore, onSnapshot } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
-import { getBoards } from '@/stores/gameBoard';
-import { getFirestore } from 'firebase/firestore';
-import { useSettingsStore } from '@/stores/settingsStore';
 import { beginSyncApply, endSyncApply } from './syncMiddleware';
-
-// Updated to use inline type instead of separate interface to avoid unused warning
+import { collectLocalUserData, writeRemoteUserData } from './sync/remoteUserData';
+import { cleanupDuplicateTiles, clearUserCustomGroups } from './sync/localCleanup';
 
 const db = getFirestore();
 
-// Export function for sync modules (avoid naming conflict with import)
-export const deleteAllCustomTiles = deleteAllIsCustomTiles;
+export { cleanupDuplicateTiles, clearUserCustomGroups };
+export { deleteAllCustomTiles } from './sync/localCleanup';
 
-// Helper function to clean up ALL duplicate tiles created by sync bug
-export async function cleanupDuplicateTiles(): Promise<boolean> {
-  try {
-    // Get all tiles to analyze duplicates
-    const allTiles = await getTiles({});
-
-    // Group tiles by composite key to find duplicates
-    const tileGroups = new Map<string, typeof allTiles>();
-
-    allTiles.forEach((tile) => {
-      const key = `${tile.group_id}|${tile.intensity}|${tile.action}`;
-      if (!tileGroups.has(key)) {
-        tileGroups.set(key, []);
-      }
-      tileGroups.get(key)!.push(tile);
-    });
-
-    // For each group, keep only the original (lowest ID) and remove ALL duplicates
-    for (const [, tiles] of tileGroups) {
-      if (tiles.length > 1) {
-        // Sort by ID to find original (lowest ID)
-        tiles.sort((a, b) => (a.id || 0) - (b.id || 0));
-        const original = tiles[0];
-        const duplicates = tiles.slice(1);
-
-        // Check if any duplicate was disabled (user's intent)
-        const wasDisabled = duplicates.some((tile) => tile.isEnabled === 0);
-
-        // Delete ALL duplicates regardless of enabled state
-        for (const duplicate of duplicates) {
-          if (duplicate.id) {
-            await deleteCustomTile(duplicate.id);
-          }
-        }
-
-        // If any duplicate was disabled, disable the original (preserve user intent)
-        if (wasDisabled && original.isEnabled === 1) {
-          await updateCustomTile(original.id!, { isEnabled: 0 });
-        }
-      }
-    }
-
-    return true;
-  } catch (error) {
-    console.error('Error cleaning up duplicate tiles:', error);
-    return false;
-  }
-}
-
-// Helper function to clear only user-created custom groups (preserve default groups)
-export async function clearUserCustomGroups(): Promise<boolean> {
-  try {
-    const userGroups = await getCustomGroups({ isDefault: false });
-
-    // Deliberately NOT cascadeDelete: deleteGroup refuses tile-owning groups,
-    // which is load-bearing here. The re-import that follows strips incoming
-    // ids and re-adds tiles under fresh local ids, so cascading would destroy
-    // tiles the pull cannot faithfully restore. A refused delete still counts
-    // as success — the group is about to be overwritten by the cloud copy.
-    const deletePromises = userGroups.map((group) => deleteGroup(group.id));
-    await Promise.all(deletePromises);
-
-    return true;
-  } catch (error) {
-    console.error('Error deleting user custom groups:', error);
-    return false;
-  }
-}
-
-// Old clients read a flat `disabledDefaults` array (no tombstones) and skip it
-// entirely when it exceeds 100, so we best-effort cap the legacy field there.
-const LEGACY_DISABLED_CAP = 100;
-// The full record set (incl. tombstones) shares the single ~1 MiB `user-data`
-// doc with tiles/groups/boards/settings, so it must stay bounded. Genuine usage
-// is small; exceeding this signals corruption — drop loudly, never silently.
-const DISABLED_V2_MAX = 1000;
-
-// Sync custom tiles to Firebase (user-created content only).
-export async function syncCustomTilesToFirebase(): Promise<boolean> {
-  const auth = getAuth();
-  const user = auth.currentUser;
-
-  if (!user) {
-    console.error('No user logged in');
-    return false;
-  }
-
-  try {
-    const customTiles = await getTiles({ isCustom: 1 });
-
-    await setDoc(
-      doc(db, 'user-data', user.uid),
-      {
-        customTiles,
-        lastUpdated: new Date(),
-      },
-      { merge: true }
-    );
-
-    return true;
-  } catch (error) {
-    console.error('Error syncing custom tiles:', error);
-    return false;
-  }
-}
-
-// Sync disabled defaults to Firebase. Writes two fields into the shared user
-// doc: `disabledDefaultsV2` (full per-record set with tombstones + updatedAt,
-// the source of truth for new clients) and a legacy `disabledDefaults` array
-// (active-only, capped) so pre-V2 clients still converge.
-export async function syncDisabledDefaultsToFirebase(): Promise<boolean> {
-  const auth = getAuth();
-  const user = auth.currentUser;
-
-  if (!user) {
-    console.error('No user logged in');
-    return false;
-  }
-
-  try {
-    const { getAllDisabledRecords } = await import('@/stores/disabledDefaults');
-    let records = await getAllDisabledRecords();
-
-    if (records.length > DISABLED_V2_MAX) {
-      const dropped = records.length - DISABLED_V2_MAX;
-      console.warn(
-        `⚠️ ${records.length} disabled-default records exceeds the ${DISABLED_V2_MAX} cap; ` +
-          `dropping ${dropped} from sync. This likely indicates corrupted local data.`
-      );
-      records = records.slice(0, DISABLED_V2_MAX);
-    }
-
-    // Legacy array: active-only, in the shape old clients expect.
-    const legacyActive = records
-      .filter((r) => r.active)
-      .map((r) => ({ group_id: r.group_id, intensity: r.intensity, action: r.action }));
-    if (legacyActive.length > LEGACY_DISABLED_CAP) {
-      legacyActive.splice(LEGACY_DISABLED_CAP);
-    }
-
-    await setDoc(
-      doc(db, 'user-data', user.uid),
-      {
-        disabledDefaults: legacyActive,
-        disabledDefaultsV2: records,
-        lastUpdated: new Date(),
-      },
-      { merge: true }
-    );
-
-    return true;
-  } catch (error) {
-    console.error('Error syncing disabled defaults:', error);
-    return false;
-  }
-}
-
-// Sync only user-created custom groups to Firebase (NOT default groups)
-export async function syncCustomGroupsToFirebase(): Promise<boolean> {
-  const auth = getAuth();
-  const user = auth.currentUser;
-
-  if (!user) {
-    console.error('No user logged in');
-    return false;
-  }
-
-  try {
-    // Get only user-created custom groups (not default groups)
-    const customGroups = await getCustomGroups({ isDefault: false });
-
-    // Create a document in Firebase with only user-created custom groups
-    await setDoc(
-      doc(db, 'user-data', user.uid),
-      {
-        customGroups,
-        lastUpdated: new Date(),
-      },
-      { merge: true }
-    );
-
-    return true;
-  } catch (error) {
-    console.error('Error syncing custom groups:', error);
-    return false;
-  }
-}
-
-// Sync user-appended intensity levels on default groups (small deltas; default
-// groups themselves never sync — each device seeds them locally).
-export async function syncGroupExtensionsToFirebase(): Promise<boolean> {
-  const auth = getAuth();
-  const user = auth.currentUser;
-
-  if (!user) {
-    console.error('No user logged in');
-    return false;
-  }
-
-  try {
-    const { collectGroupExtensionRecords } = await import('./sync/customGroupExtensionsSync');
-    const customGroupExtensions = await collectGroupExtensionRecords();
-
-    await setDoc(
-      doc(db, 'user-data', user.uid),
-      {
-        customGroupExtensions,
-        lastUpdated: new Date(),
-      },
-      { merge: true }
-    );
-
-    return true;
-  } catch (error) {
-    console.error('Error syncing group extensions:', error);
-    return false;
-  }
-}
-
-// Sync game boards to Firebase
-export async function syncGameBoardsToFirebase(): Promise<boolean> {
-  const auth = getAuth();
-  const user = auth.currentUser;
-
-  if (!user) {
-    console.error('No user logged in');
-    return false;
-  }
-
-  try {
-    // Get all game boards from Dexie
-    const gameBoards = await getBoards();
-
-    if (!gameBoards.length) {
-      return true;
-    }
-
-    // Create a document in Firebase with all game boards
-    await setDoc(
-      doc(db, 'user-data', user.uid),
-      {
-        gameBoards,
-        lastUpdated: new Date(),
-      },
-      { merge: true }
-    );
-
-    return true;
-  } catch (error) {
-    console.error('Error syncing game boards:', error);
-    return false;
-  }
-}
-
-// Sync user settings (including theme preferences) to Firebase
-export async function syncSettingsToFirebase(): Promise<boolean> {
-  const auth = getAuth();
-  const user = auth.currentUser;
-
-  if (!user) {
-    console.error('No user logged in');
-    return false;
-  }
-
-  try {
-    // Get current settings from store
-    const { settings } = useSettingsStore.getState();
-
-    // Filter out local player settings and any undefined values - they should stay in React app only
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { localPlayers, ...settingsForFirebase } = settings;
-
-    // Remove any undefined values from settings to prevent Firebase errors
-    const cleanSettings = Object.fromEntries(
-      Object.entries(settingsForFirebase).filter(([, value]) => value !== undefined)
-    );
-
-    // Create a document in Firebase with filtered user settings
-    await setDoc(
-      doc(db, 'user-data', user.uid),
-      {
-        settings: cleanSettings,
-        lastUpdated: new Date(),
-      },
-      { merge: true }
-    );
-
-    return true;
-  } catch (error) {
-    console.error('Error syncing settings:', error);
-    return false;
-  }
-}
-
-// Sync all data to Firebase. Runs every step (so one failure doesn't block the
-// rest) but returns false if any step failed, instead of masking partial failures.
+/**
+ * Publish this device's whole snapshot in one write. Every push path funnels
+ * here: there is no per-entity push, so a cycle can never leave the document
+ * half-updated.
+ */
 export async function syncAllDataToFirebase(): Promise<boolean> {
-  const results = [
-    await syncCustomTilesToFirebase(),
-    await syncDisabledDefaultsToFirebase(),
-    await syncCustomGroupsToFirebase(),
-    await syncGroupExtensionsToFirebase(),
-    await syncGameBoardsToFirebase(),
-    await syncSettingsToFirebase(),
-  ];
-  return results.every(Boolean);
-}
-
-// Intelligent sync that handles conflicts - meant for user-initiated sync
-export async function intelligentSync(): Promise<{ success: boolean; conflicts?: string[] }> {
-  const auth = getAuth();
-  const user = auth.currentUser;
+  const user = getAuth().currentUser;
 
   if (!user) {
-    return { success: false, conflicts: ['No user logged in'] };
+    console.error('No user logged in');
+    return false;
   }
 
   try {
-    // Get both local and Firebase data
-    const userDocRef = doc(db, 'user-data', user.uid);
-    const userDoc = await getDoc(userDocRef);
-
-    const localCustomTiles = await getTiles({ isCustom: 1 });
-    const localCustomGroups = await getCustomGroups({ isDefault: false });
-
-    const conflicts: string[] = [];
-
-    if (!userDoc.exists()) {
-      // No Firebase data - sync local to Firebase
-      await syncAllDataToFirebase();
-      return { success: true };
-    }
-
-    const userData = userDoc.data();
-    const firebaseCustomTiles = (userData.customTiles as CustomTilePull[]) || [];
-    const firebaseCustomGroups = (userData.customGroups as CustomGroupPull[]) || [];
-
-    // Check for conflicts
-    if (localCustomTiles.length > 0 && firebaseCustomTiles.length > 0) {
-      conflicts.push(
-        `Custom tiles: Local has ${localCustomTiles.length}, Firebase has ${firebaseCustomTiles.length}`
-      );
-    }
-
-    if (localCustomGroups.length > 0 && firebaseCustomGroups.length > 0) {
-      conflicts.push(
-        `Custom groups: Local has ${localCustomGroups.length}, Firebase has ${firebaseCustomGroups.length}`
-      );
-    }
-
-    if (conflicts.length > 0) {
-      return { success: false, conflicts };
-    }
-
-    // No conflicts - proceed with normal sync
-    const result = await syncDataFromFirebase();
-    return { success: result };
+    await writeRemoteUserData(user.uid, await collectLocalUserData());
+    return true;
   } catch (error) {
-    console.error('Error in intelligent sync:', error);
-    return { success: false, conflicts: ['Sync failed due to error'] };
+    console.error('Error syncing data to Firebase:', error);
+    return false;
   }
 }
 
@@ -390,7 +43,6 @@ export async function intelligentSync(): Promise<{ success: boolean; conflicts?:
 export async function syncDataFromFirebase(
   options: { forceSync?: boolean } = {}
 ): Promise<boolean> {
-  // Use the new sync orchestrator for better maintainability
   const { SyncOrchestrator } = await import('./sync/syncOrchestrator');
   // Suppress the sync middleware while applying remote changes so the writes
   // below don't schedule an echo push back to Firebase.
@@ -450,10 +102,8 @@ export function startPeriodicSync(intervalMinutes = 5): boolean {
   // Clear any existing interval first
   stopPeriodicSync();
 
-  // Convert minutes to milliseconds
   const intervalMs = intervalMinutes * 60 * 1000;
 
-  // Set up the interval
   syncIntervalId = window.setInterval(async () => {
     const auth = getAuth();
     if (auth.currentUser && !auth.currentUser.isAnonymous) {

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -12,10 +12,6 @@ import 'fake-indexeddb/auto';
 // Mock syncService to prevent auth context errors - must be before other imports
 vi.mock('@/services/syncService', () => ({
   syncDataFromFirebase: () => Promise.resolve(true),
-  syncCustomTilesToFirebase: () => Promise.resolve(true),
-  syncCustomGroupsToFirebase: () => Promise.resolve(true),
-  syncGameBoardsToFirebase: () => Promise.resolve(true),
-  syncSettingsToFirebase: () => Promise.resolve(true),
   syncAllDataToFirebase: () => Promise.resolve(true),
   startPeriodicSync: () => {},
   stopPeriodicSync: () => {},

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -11,6 +11,12 @@ export interface SyncResult {
   itemsProcessed?: number;
   conflicts?: string[];
   errors?: string[];
+  /**
+   * The merge altered local state (or local content the cloud lacks was found),
+   * so the cycle owes the cloud one push. Entity merges never push themselves —
+   * the orchestrator publishes once, after every merge has finished.
+   */
+  changed?: boolean;
 }
 
 export interface SyncConflictResolution {
@@ -30,9 +36,4 @@ export interface ConflictInfo {
   localCount: number;
   remoteCount: number;
   description: string;
-}
-
-export interface IntelligentSyncResult {
-  success: boolean;
-  conflicts: string[];
 }


### PR DESCRIPTION
Wave 3, card 5 of the architecture review. Independent of #1135 (card 9, merged).

## The problem

`user-data/{uid}` is **one** Firestore document, but knowledge of it was spread across eight files:

- **Six sequential writes per push.** `syncAllDataToFirebase` awaited six functions, each opening its own `setDoc(..., { merge: true })` on the same document. Editing one tile cost six round trips and six billed writes, debounced at 2 s.
- **The pull path pushed mid-pull.** `CustomTilesSync`, `CustomGroupsSync` and `DisabledDefaultsSync` each called their own push *from inside* the merge, while `Promise.allSettled` ran the other merges concurrently — so a cycle could publish a half-merged document, and each push was a fresh echo candidate for the real-time listener.
- **An import cycle.** Four modules under `sync/` imported back into `syncService`, which dynamically imports them.
- **The one helper that centralized the document path (`base.getUserDocument`) was bypassed by every writer**, each rebuilding `doc(db, 'user-data', uid)` — off a second Firestore handle, no less.

## The change

**`src/services/sync/remoteUserData.ts` owns the document.** Nothing above it knows a field name:

| | |
|---|---|
| `readRemoteUserData(uid)` | one `getDoc`, decoded into the app's vocabulary; `null` = no document yet |
| `collectLocalUserData()` | this device's whole snapshot, from Dexie + the settings store |
| `writeRemoteUserData(uid, local)` | one `setDoc` merge |

Encoding quirks that used to be re-derived per writer now live there once: the dual legacy/`disabledDefaultsV2` fields (read prefers V2, and up-converts a legacy-only document so merges only ever see records), the 100/1000 caps, `localPlayers` and `undefined` stripping, and the rule that **a board-less device must not blank another device's boards**.

**One cycle = one read, then one write if anything changed.** Entity merges return `changed` instead of pushing; `syncOrchestrator` publishes once, after every merge settles. The push-only-on-change invariant that keeps the listener from looping is preserved exactly — it just moved up one level.

**`sync/localCleanup.ts`** holds the local repairs (`cleanupDuplicateTiles`, `clearUserCustomGroups`, `deleteAllCustomTiles`) that the merges needed and that made them import their own caller. `grep -rn syncService src/services/sync/` now returns only a comment.

`syncService.ts` drops from 483 to ~130 lines and decides one thing: *when* a cycle runs.

## Deleted: `intelligentSync`

It declared a "conflict" whenever both sides were merely non-empty and refused to sync — contradicting the LWW merge the same file performs everywhere else. It was plumbed through `useAuthSync` onto the auth context, and **no UI ever called it** (`grep` for `.intelligentSync` outside those files returns nothing). Gone with its `IntelligentSyncResult` type.

## Behaviour

| | before | after |
|---|---|---|
| writes per push | 6 | 1 |
| writes during a pull that merged | up to 3, mid-merge | 1, after all merges |
| writes during a no-op pull | 0 | 0 |

Pull semantics, LWW (`remoteWins`, strict `>`), tombstones, caps, the surgical default-content preservation and the device-local active-board rule are unchanged.

## Tests

`syncService.test.ts` was an SDK-shape test asserting per-function `setDoc` payloads; each behaviour it pinned was mapped onto the new boundary rather than dropped — plus new coverage for one-write-per-push, one-publish-per-cycle, no-publish-when-nothing-changed, the V2 cap, and `gameBoards` omission. `sync/__tests__/remoteUserData.test.ts` unit-tests the decode (absent vs present-but-empty, V2-over-legacy, legacy up-convert).

**Mutation-tested**: publishing unconditionally makes *does not push when no merge changed anything* fail; always writing `gameBoards` makes the omission test fail. Both restored, both green.

One test-harness fix included: the file's store mocks now live in the outer `beforeEach`, because `vitest.ci.config.ts` resets mock implementations between tests while `vitest.config.ts` does not — the push path's new fan-out made that divergence load-bearing.

## Gate

`npm run type-check` clean · `npx eslint src/` 0 errors / 52 warnings (unchanged) · **175 files / 1837 tests pass** (verified under both vitest configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)