### PR TITLE
fix(settings): one catalog builder, so the settings message names the right level

### DIFF
--- a/src/hooks/useUnifiedActionList.ts
+++ b/src/hooks/useUnifiedActionList.ts
@@ -4,6 +4,7 @@ import { getAllAvailableGroups } from '@/stores/customGroups';
 import { getGroupsWithTiles, getTileCountsByGroup } from '@/stores/contentLibrary';
 import { deriveContentMode } from '@/stores/settingsStore';
 import { getGroupRoleLabels } from '@/services/groupRoleLabels';
+import { convertDexieGroupsToActions } from '@/services/dexieActionImport';
 import { GroupedActions } from '@/types/customTiles';
 
 interface UnifiedActionListResult {
@@ -103,30 +104,13 @@ export default function useUnifiedActionList(
         // groups without bespoke wording simply aren't in the map.
         const roleLabels = await getGroupRoleLabels(locale, contentGameMode);
 
-        // Convert groups to unified actions structure
-        const unifiedActions: GroupedActions = {};
+        // One catalog builder for every actions list, so the settings UI and the
+        // room's settings message can never disagree on level numbering.
+        const unifiedActions = convertDexieGroupsToActions(allGroups);
 
         for (const group of allGroups) {
-          const actions: Record<string, string[]> = {};
-
-          const intensities: Record<number, string> = {};
-
-          // Build intensities map from group data
-          if (group.intensities && Array.isArray(group.intensities)) {
-            group.intensities
-              .sort((a, b) => a.value - b.value)
-              .forEach((intensity) => {
-                actions[intensity.label] = [];
-                intensities[intensity.value] = intensity.label;
-              });
-          }
-
-          // Ensure each group has a proper label for Quick Start display
           unifiedActions[group.name] = {
-            label: group.label || group.name,
-            type: group.type || 'action',
-            actions,
-            intensities,
+            ...unifiedActions[group.name],
             usesRoleTokens: roleTokenGroupIds.has(group.id),
             ...roleLabels[group.name],
           };

--- a/src/services/__tests__/dexieActionImport.test.ts
+++ b/src/services/__tests__/dexieActionImport.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertDexieGroupsToActions } from '@/services/dexieActionImport';
+import type { CustomGroupPull } from '@/types/customGroups';
+
+const group = (overrides: Partial<CustomGroupPull> = {}): CustomGroupPull =>
+  ({
+    id: 'g1',
+    name: 'throatTraining',
+    label: 'Throat Training',
+    type: 'solo',
+    locale: 'en',
+    gameMode: 'online',
+    isDefault: true,
+    intensities: [
+      { id: 'i1', label: 'Lick Toy', value: 1, isDefault: true },
+      { id: 'i2', label: 'Suck Toy', value: 2, isDefault: true },
+      { id: 'i3', label: 'Deepthroat', value: 3, isDefault: true },
+    ],
+    ...overrides,
+  }) as CustomGroupPull;
+
+describe('convertDexieGroupsToActions', () => {
+  // A phantom "None" level used to be injected as the first action key. Every
+  // consumer that maps a 1-based level to an action-key index then read one
+  // label too low, and level 1 rendered as "None" — visible in the room's
+  // settings message.
+  it('does not inject a phantom None level', () => {
+    const actions = convertDexieGroupsToActions([group()]);
+
+    expect(Object.keys(actions.throatTraining.actions ?? {})).toEqual([
+      'Lick Toy',
+      'Suck Toy',
+      'Deepthroat',
+    ]);
+  });
+
+  it('exposes intensities keyed by level value so consumers never index by position', () => {
+    const actions = convertDexieGroupsToActions([group()]);
+
+    expect(actions.throatTraining.intensities).toEqual({
+      1: 'Lick Toy',
+      2: 'Suck Toy',
+      3: 'Deepthroat',
+    });
+  });
+
+  it('orders levels by value regardless of stored order', () => {
+    const actions = convertDexieGroupsToActions([
+      group({
+        intensities: [
+          { id: 'i3', label: 'Deepthroat', value: 3, isDefault: true },
+          { id: 'i1', label: 'Lick Toy', value: 1, isDefault: true },
+          { id: 'i2', label: 'Suck Toy', value: 2, isDefault: true },
+        ],
+      }),
+    ]);
+
+    expect(Object.keys(actions.throatTraining.actions ?? {})).toEqual([
+      'Lick Toy',
+      'Suck Toy',
+      'Deepthroat',
+    ]);
+  });
+
+  it('keeps the group label and type', () => {
+    const actions = convertDexieGroupsToActions([group()]);
+
+    expect(actions.throatTraining.label).toBe('Throat Training');
+    expect(actions.throatTraining.type).toBe('solo');
+  });
+});

--- a/src/services/__tests__/gameSettingsMessage.test.ts
+++ b/src/services/__tests__/gameSettingsMessage.test.ts
@@ -1,7 +1,121 @@
 import { describe, expect, it } from 'vitest';
 
-import { exportSettings } from '@/services/gameSettingsMessage';
-import type { Settings } from '@/types/Settings';
+import { exportSettings, getSettingsMessage } from '@/services/gameSettingsMessage';
+import { convertDexieGroupsToActions } from '@/services/dexieActionImport';
+import db from '@/stores/store';
+import type { CustomGroupPull } from '@/types/customGroups';
+import type { PlayerRole, Settings } from '@/types/Settings';
+
+describe('getSettingsMessage', () => {
+  const throatTraining = {
+    id: 'g1',
+    name: 'throatTraining',
+    label: 'Throat Training',
+    type: 'solo',
+    locale: 'en',
+    gameMode: 'online',
+    isDefault: true,
+    intensities: [
+      { id: 'i1', label: 'Lick Toy', value: 1, isDefault: true },
+      { id: 'i2', label: 'Suck Toy', value: 2, isDefault: true },
+      { id: 'i3', label: 'Deepthroat', value: 3, isDefault: true },
+    ],
+  } as CustomGroupPull;
+
+  // Room-entry and rebuilt-board messages build their catalog through
+  // `convertDexieGroupsToActions`, so the two must agree on level numbering.
+  // They didn't: the catalog injected a phantom "None" first key, so the
+  // message named every selected level one step too low.
+  it('names the levels the player actually selected', async () => {
+    const settings: Settings = {
+      gameMode: 'solo',
+      boardUpdated: false,
+      room: 'PUBLIC',
+      selectedActions: { throatTraining: { type: 'solo', levels: [1, 2] } },
+    } as Settings;
+
+    const message = await getSettingsMessage(
+      settings,
+      [],
+      convertDexieGroupsToActions([throatTraining])
+    );
+
+    expect(message).toContain('Lick Toy');
+    expect(message).toContain('Suck Toy');
+    expect(message).not.toContain('None');
+  });
+
+  it('names a level by its VALUE, so a sparse ladder stays correct', async () => {
+    const sparse = { ...throatTraining, intensities: [throatTraining.intensities[2]] };
+    const settings: Settings = {
+      gameMode: 'solo',
+      boardUpdated: false,
+      room: 'PUBLIC',
+      selectedActions: { throatTraining: { type: 'solo', levels: [3] } },
+    } as Settings;
+
+    const message = await getSettingsMessage(settings, [], convertDexieGroupsToActions([sparse]));
+
+    expect(message).toContain('Deepthroat');
+  });
+
+  // Counts a custom tile when its intensity is one the player SELECTED. The
+  // old rule compared against the level COUNT, so picking levels [1, 3] counted
+  // tiles at 1 and 2 — an unselected level in, a selected one out.
+  it('counts custom tiles at selected levels only', async () => {
+    const settings = {
+      gameMode: 'solo',
+      boardUpdated: false,
+      room: 'PUBLIC',
+      selectedActions: { throatTraining: { type: 'solo', levels: [1, 3] } },
+    } as Settings;
+    const tile = (intensity: number) =>
+      ({ group_id: 'g1', intensity, isCustom: 1, action: 'x' }) as never;
+    // Tiles resolve to a group by id, so the row has to exist.
+    await db.customGroups.put({ ...throatTraining, createdAt: new Date() } as never);
+
+    const message = await getSettingsMessage(
+      settings,
+      [tile(1), tile(2), tile(3)],
+      convertDexieGroupsToActions([throatTraining])
+    );
+
+    expect(message).toContain('customTilesLabel: 2');
+  });
+
+  describe('role wording', () => {
+    const partnered = {
+      throatTraining: { ...convertDexieGroupsToActions([throatTraining]).throatTraining },
+    };
+    partnered.throatTraining.dom = 'Receive Oral';
+    partnered.throatTraining.sub = 'Give Oral';
+
+    const withRole = (role: PlayerRole): Settings =>
+      ({
+        gameMode: 'online',
+        boardUpdated: false,
+        soloPlay: false,
+        room: 'PUBLIC',
+        role,
+        selectedActions: { throatTraining: { type: 'sex', levels: [1] } },
+      }) as Settings;
+
+    it("uses the group's own wording for dom and sub", async () => {
+      expect(await getSettingsMessage(withRole('dom'), [], partnered)).toContain('Receive Oral');
+      expect(await getSettingsMessage(withRole('sub'), [], partnered)).toContain('Give Oral');
+    });
+
+    // Only the two sides have bespoke wording; a Switch player gets the
+    // generic label rather than being silently shown one side's wording.
+    it('falls back to the generic label for vers (Switch)', async () => {
+      const message = await getSettingsMessage(withRole('vers'), [], partnered);
+
+      expect(message).toContain('vers');
+      expect(message).not.toContain('Receive Oral');
+      expect(message).not.toContain('Give Oral');
+    });
+  });
+});
 
 describe('exportSettings', () => {
   it('drops personal Hands-Free preferences from the exported settings', () => {

--- a/src/services/dataCompletenessChecker.ts
+++ b/src/services/dataCompletenessChecker.ts
@@ -78,11 +78,7 @@ export const checkDataCompleteness = async (
       };
 
       if (expectedGroup?.actions) {
-        // Count expected intensities (excluding 'None')
-        const expectedIntensityKeys = Object.keys(expectedGroup.actions).filter(
-          (key) => key !== 'None'
-        );
-        groupDetail.expectedIntensities = expectedIntensityKeys.length;
+        groupDetail.expectedIntensities = Object.keys(expectedGroup.actions).length;
       }
 
       if (dexieGroup) {

--- a/src/services/dexieActionImport.ts
+++ b/src/services/dexieActionImport.ts
@@ -1,46 +1,49 @@
 import { getAllAvailableGroups } from '@/stores/customGroups';
 import { CustomGroupPull } from '@/types/customGroups';
+import { GroupedActions } from '@/types/customTiles';
 import { ContentGameMode } from '@/types/Settings';
 
 /**
- * Convert Dexie custom groups to the format expected by the old importActions function
+ * The settings catalog: Dexie groups → the `{ label, type, actions, intensities }`
+ * shape every consumer of an actions list expects.
+ *
+ * `actions` carries a key per level (empty arrays — the text lives in
+ * customTiles) and `intensities` maps a level VALUE to its label. Consumers must
+ * read `intensities`: action-key position is not a level number, and a sparse
+ * ladder (a group whose levels are 1, 2, 4) makes the two disagree.
  */
-export const convertDexieGroupsToActions = (groups: CustomGroupPull[]): Record<string, any> => {
-  const actions: Record<string, any> = {};
+export const convertDexieGroupsToActions = (groups: CustomGroupPull[]): GroupedActions => {
+  const catalog: GroupedActions = {};
 
   for (const group of groups) {
-    // Convert the group to the expected format
-    const actionObj: any = {
+    const actions: Record<string, string[]> = {};
+    const intensities: Record<number, string> = {};
+
+    [...(group.intensities ?? [])]
+      .sort((a, b) => a.value - b.value)
+      .forEach((intensity) => {
+        actions[intensity.label] = [];
+        intensities[intensity.value] = intensity.label;
+      });
+
+    catalog[group.name] = {
       label: group.label || group.name,
       type: group.type || 'action',
-      actions: {
-        None: [], // Always include None as it's expected
-      },
+      actions,
+      intensities,
     };
-
-    // Convert intensities to actions format
-    if (group.intensities && Array.isArray(group.intensities)) {
-      for (const intensity of group.intensities) {
-        // For now, create empty arrays for each intensity
-        // The actual actions would come from custom tiles
-        actionObj.actions[intensity.label] = [];
-      }
-    }
-
-    actions[group.name] = actionObj;
   }
 
-  return actions;
+  return catalog;
 };
 
 /**
- * Replacement for importActions from importLocales.ts
- * Gets actions from Dexie instead of JSON files
+ * Load the settings catalog for a locale/game mode from Dexie.
  */
 export const importActions = async (
   locale = 'en',
   gameMode: ContentGameMode = 'online'
-): Promise<Record<string, any>> => {
+): Promise<GroupedActions> => {
   try {
     const groups = await getAllAvailableGroups(locale, gameMode);
     return convertDexieGroupsToActions(groups);

--- a/src/services/gameSettingsMessage.ts
+++ b/src/services/gameSettingsMessage.ts
@@ -1,7 +1,7 @@
 import { DocumentData, DocumentReference } from 'firebase/firestore';
 import { getOrCreateBoard, sendMessage } from './firebase';
 
-import { CustomTilePull } from '@/types/customTiles';
+import { CustomTilePull, GroupedActions } from '@/types/customTiles';
 import { Settings } from '@/types/Settings';
 import { TileExport } from '@/types/gameBoard';
 import { User } from '@/types';
@@ -10,37 +10,31 @@ import i18next from 'i18next';
 import { usesSoloActions } from '@/helpers/strings';
 
 /**
- * Type guard to check if an object has a valid role property
- * @param obj - The object to check
- * @param role - The role key to look for
- * @returns true if obj is an object and has the role property
+ * A group's own wording for a role — Butt Play's "Top"/"Bottom", Ball Busting's
+ * "Buster"/"Bustee". Only the two sides carry bespoke wording (see
+ * `GroupRoleLabels`), so `vers` (Switch) always falls back to the generic label.
  */
-function isValidRole(obj: unknown, role: unknown): obj is Record<string, unknown> {
-  return obj !== null && typeof obj === 'object' && typeof role === 'string' && role in obj;
-}
-
-interface ActionsList {
-  [key: string]: {
-    label: string;
-    actions: Record<string, any>;
-    [key: string]: any;
-  };
+function groupRoleWording(group: GroupedActions[string], role: string): string | undefined {
+  if (role === 'dom') return group?.dom;
+  if (role === 'sub') return group?.sub;
+  return undefined;
 }
 
 async function getCustomTileCount(
   settings: Settings,
   customTiles: CustomTilePull[] | null | undefined,
-  actionsList: ActionsList
+  actionsList: GroupedActions
 ): Promise<number> {
   // Use selectedActions structure only
   const actionEntries = settings.selectedActions || {};
 
-  const settingsDataFolder = Object.entries(actionsList)
-    .filter(([key]) => actionEntries[key])
-    .reduce<Record<string, string[]>>((acc, [key, value]) => {
-      const levels = actionEntries[key].levels || [];
-      const actionKeys = Object.keys(value.actions);
-      acc[key] = levels.map((level) => actionKeys[level]).filter(Boolean);
+  // Selected level VALUES per group. Indexing `actions` by level would be off
+  // by one (keys are positions, levels are 1-based) and wrong outright for a
+  // sparse ladder.
+  const selectedLevelsByGroup = Object.keys(actionsList)
+    .filter((key) => actionEntries[key])
+    .reduce<Record<string, number[]>>((acc, key) => {
+      acc[key] = actionEntries[key].levels || [];
       return acc;
     }, {});
 
@@ -58,8 +52,7 @@ async function getCustomTileCount(
       const groupName = groupIdToName.get(entry.group_id || '');
       if (!groupName) return false;
 
-      const intensityArray = settingsDataFolder[groupName];
-      return intensityArray && intensityArray.length >= Number(entry.intensity);
+      return !!selectedLevelsByGroup[groupName]?.includes(Number(entry.intensity));
     }) || [];
 
   return usedCustomTiles.length;
@@ -68,7 +61,7 @@ async function getCustomTileCount(
 export async function getSettingsMessage(
   settings: Settings,
   customTiles: CustomTilePull[] | null | undefined,
-  actionsList: ActionsList,
+  actionsList: GroupedActions,
   reason?: string
 ): Promise<string> {
   const { t } = i18next;
@@ -96,9 +89,7 @@ export async function getSettingsMessage(
       if (variation) {
         modifier = t(variation);
       } else if (!usesSoloActions(settings.gameMode, settings.soloPlay)) {
-        modifier = isValidRole(val, actualRole)
-          ? (val[actualRole as string] as string)
-          : t(actualRole as string);
+        modifier = groupRoleWording(val, actualRole as string) ?? t(actualRole as string);
       }
 
       if (modifier) {
@@ -107,28 +98,13 @@ export async function getSettingsMessage(
 
       message += '\r\n';
 
-      // Get intensity names for selected levels
+      // Level VALUE → label. Never fall back to the position of a key in
+      // `actions`: a sparse ladder makes position and level disagree, and the
+      // catalog used to prepend a phantom level, which named every selected
+      // level one step too low.
       const intensityNames = val?.intensities || {};
       levels.forEach((level: number) => {
-        let levelName = intensityNames[level];
-
-        // If no intensity name found, try to get it from the actions object
-        if (!levelName && val?.actions && typeof val.actions === 'object') {
-          const actionKeys = Object.keys(val.actions);
-          // Action keys are ordered, with level corresponding to index
-          // Level 1 = index 0
-          const actionIndex = level - 1; // Convert 1-based level to 0-based index
-          if (actionIndex >= 0 && actionIndex < actionKeys.length) {
-            levelName = actionKeys[actionIndex];
-          }
-        }
-
-        // Final fallback to Level X
-        if (!levelName) {
-          levelName = `Level ${level}`;
-        }
-
-        message += `* ${levelName}\r\n`;
+        message += `* ${intensityNames[level] || `Level ${level}`}\r\n`;
       });
       message += '\r\n';
     }
@@ -242,7 +218,7 @@ interface SendMessageOptions {
   title: string;
   formData: Settings;
   user: User;
-  actionsList: ActionsList;
+  actionsList: GroupedActions;
   tiles: TileExport[];
   customTiles?: CustomTilePull[];
   reason?: string;


### PR DESCRIPTION
## The bug

Players saw a phantom `None` level in the room's settings message, with every other level named one step too low:

```
Game Settings
Alcohol: Standalone Tile
* None          <- should be Sip/Drink
* Sip/Drink     <- should be Shots

Chest Play
* None          <- should be Squeeze/Rub
* Squeeze/Rub   <- should be Pinch/Pull
```

Reported live twice: `Bating` at levels [1, 2] printed `None` / `Masturbation` (real ladder is Masturbation, Edging, Toys), and `Poppers` at level [1] printed just `None` (real level 1 is Beginner).

## Cause

`convertDexieGroupsToActions` injected a hardcoded first action key and never emitted an `intensities` map:

```js
actions: { None: [] },  // "Always include None as it's expected"
```

With no `intensities` to read, `getSettingsMessage` fell back to **position** — `Object.keys(actions)[level - 1]` — so level 1 resolved to the phantom key and everything after it shifted down one.

It hit the two message paths that build their catalog through `importActions`:

| Path | Catalog source | Affected |
| --- | --- | --- |
| Room entry (`useSendSettings`) | `importActions` | yes |
| Rebuilt board (`usePrivateRoomMonitor`) | `importActions` | yes |
| "Settings updated" (MenuDrawer) | `useUnifiedActionList` | no |

That's why only some messages looked wrong.

## Fix

`convertDexieGroupsToActions` becomes the single catalog builder — no phantom level, `intensities` keyed by level **value**, ordered by value. `useUnifiedActionList` reuses it instead of duplicating the conversion, so the settings UI and the room message can no longer disagree on numbering.

The positional fallback is deleted rather than patched: it also mis-named sparse ladders (a group with levels 1, 2, 4).

### Two adjacent bugs the phantom level was masking

- `getCustomTileCount` counted a custom tile when its intensity was `<=` the **number** of selected levels, so picking levels [1, 3] counted tiles at intensities 1 and 2 — an unselected level in, a selected one out. It now counts tiles at the levels actually selected.
- `dataCompletenessChecker` no longer needs its `key !== 'None'` workaround.

### Role wording

Replaces the `role in obj` lookup with an explicit dom/sub accessor. Behaviour is unchanged: only those two sides ever carry bespoke wording (`GroupRoleLabels`), so `vers` (Switch) still falls back to the generic label. A test now pins that.

## Tests

Six new tests, red before the change — the first reproduced the reported output verbatim (`* None` / `* Lick Toy`):

- catalog emits no phantom level, and `intensities` keyed by value, ordered by value
- message names the levels actually selected
- message stays correct for a sparse ladder
- custom tiles counted at selected levels only
- dom/sub use the group's own wording; `vers` falls back to generic

## Gate

`npm run type-check` clean · `npx eslint src/` 0 errors / 52 warnings · 176 files / 1847 tests pass

## Follow-ups, not in this PR

- One sample showed the stale label "Tit Torture" (current bundle says "Chest Play"). The rename shipped Nov 2025 and `MIGRATION_VERSION` reached 2.6.0 in June 2026, which forces a re-seed, so a current client should render "Chest Play" — most likely an older message still in room history.
- `src/components/GameForm/IncrementalSelect` has no importers and treats levels as 0-based indexes into action keys. Deletion candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
